### PR TITLE
Add coroutine imports and dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -95,12 +95,10 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:$okhttp_version") // OkHttp (HTTP client)
     implementation("com.squareup.okhttp3:logging-interceptor:$okhttp_version") // Interceptor untuk logging (membantu debugging)
 
-    // ---- Kotlin Coroutines Core (jika belum ada) ----
-    // Pastikan Anda sudah punya implementasi coroutines-core dan coroutines-android.
-    // Biasanya sudah datang dengan room-ktx atau lifecycle-viewmodel-ktx,
-    // tapi tidak ada salahnya memastikan.
-    // implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0") // Ganti dengan versi terbaru
-    // implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0") // Ganti dengan versi terbaru
+    // ---- Kotlin Coroutines Core ----
+    // Menambahkan dependensi eksplisit untuk coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.0")
 
 
     // ---- Dependensi pengujian (sudah ada, hanya peninjauan) ----

--- a/app/src/main/java/com/example/diarydepresiku/DiaryRepository.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryRepository.kt
@@ -2,6 +2,7 @@ package com.example.diarydepresiku
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.Flow
 import java.util.concurrent.TimeUnit // Untuk penggunaan waktu yang lebih jelas
 
 // Repository bertanggung jawab untuk abstraksi akses data (lokal & remote)

--- a/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 


### PR DESCRIPTION
## Summary
- import `MutableStateFlow` and `asStateFlow`
- import `Flow` in repository
- add `kotlinx-coroutines-core` and `kotlinx-coroutines-android` dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a05c49f08324a27de2ebd279a77f