### PR TITLE
Update Compose BOM and SDK settings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 
 android {
     namespace = "com.example.diarydepresiku"
-    compileSdk = 35 // OK
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.example.diarydepresiku"
         minSdk = 24 // OK
-        targetSdk = 35 // OK
+        targetSdk = 34
         versionCode = 1 // OK
         versionName = "1.0" // OK
 
@@ -45,7 +45,7 @@ android {
         // viewBinding = true // Tambahkan ini jika Anda juga menggunakan View Binding
     }
     composeOptions { // Tambahkan ini untuk konfigurasi Compose
-        kotlinCompilerExtensionVersion = "1.5.1" // Pastikan versi ini sesuai dengan versi Kotlin Anda
+        kotlinCompilerExtensionVersion = "1.5.15"
         // Anda mungkin perlu menyesuaikannya dengan compileSdk dan Kotlin plugin
     }
     packaging { // Konfigurasi untuk mencegah konflik file di APK

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
-composeBom = "2024.09.00"
+composeBom = "2025.06.00"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
## Summary
- update Compose BOM to `2025.06.00`
- bump Compose compiler extension to `1.5.15`
- set `compileSdk`/`targetSdk` to API 34

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a28858ec8324acb60b0ea7e266b4