### PR TITLE
Add CRUD module for FastAPI backend

### DIFF
--- a/app/backend_api/app/crud.py
+++ b/app/backend_api/app/crud.py
@@ -1,0 +1,29 @@
+from sqlalchemy.orm import Session
+from typing import List, Optional
+
+from . import models, schemas
+
+
+def create_diary_entry(db: Session, entry: schemas.DiaryEntryCreate) -> models.DiaryEntry:
+    """Create a new diary entry and persist it to the database."""
+    db_entry = models.DiaryEntry(**entry.model_dump())
+    db.add(db_entry)
+    db.commit()
+    db.refresh(db_entry)
+    return db_entry
+
+
+def get_diary_entries(db: Session, skip: int = 0, limit: int = 100) -> List[models.DiaryEntry]:
+    """Return a list of diary entries ordered by newest timestamp."""
+    return (
+        db.query(models.DiaryEntry)
+        .order_by(models.DiaryEntry.timestamp.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+def get_diary_entry(db: Session, entry_id: int) -> Optional[models.DiaryEntry]:
+    """Return a single diary entry by ID or None if not found."""
+    return db.query(models.DiaryEntry).filter(models.DiaryEntry.id == entry_id).first()

--- a/app/backend_api/app/main.py
+++ b/app/backend_api/app/main.py
@@ -3,7 +3,7 @@ from fastapi import FastAPI, Depends, HTTPException, status # Import status dan 
 from sqlalchemy.orm import Session
 from typing import List # Untuk tipe hint List
 
-from backend_api import crud # Tambahkan import crud
+from . import crud  # Import modul CRUD lokal
 from . import models, schemas
 from .database import engine, get_db
 


### PR DESCRIPTION
## Summary
- implement CRUD utility for diary entries
- update FastAPI app to import the new module

## Testing
- `python -m py_compile app/backend_api/app/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849a3ece7ec832480f9507d0e63505a