### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# Development Guidelines
+
+## Build the Android app
+Run:
+```bash
+./gradlew assembleDebug
+```
+
+## Run Android unit tests
+Run:
+```bash
+./gradlew test
+```
+
+## Start the FastAPI backend
+From the project root, run:
+```bash
+cd app/backend_api && uvicorn app.main:app --reload
+```
+
+## General guidelines
+- Run any configured formatters before committing code.
+- Do **not** commit OS artifacts such as `.DS_Store` or `Thumbs.db`.
+- Ensure every file ends with a trailing newline.


### PR DESCRIPTION
## Summary
- add development instructions and guidelines in root AGENTS.md

## Testing
- `./gradlew tasks --all | grep -i format | head`

------
https://chatgpt.com/codex/tasks/task_e_6849d40990748324ad71c3ba6c94abef