### PR TITLE
Add mood stats endpoint

### DIFF
--- a/app/backend_api/app/crud.py
+++ b/app/backend_api/app/crud.py
@@ -1,10 +1,13 @@
 from sqlalchemy.orm import Session
-from typing import List, Optional
+from sqlalchemy import func
+from typing import List, Optional, Dict
 
 from . import models, schemas
 
 
-def create_diary_entry(db: Session, entry: schemas.DiaryEntryCreate) -> models.DiaryEntry:
+def create_diary_entry(
+    db: Session, entry: schemas.DiaryEntryCreate
+) -> models.DiaryEntry:
     """Create a new diary entry and persist it to the database."""
     db_entry = models.DiaryEntry(**entry.model_dump())
     db.add(db_entry)
@@ -13,7 +16,9 @@ def create_diary_entry(db: Session, entry: schemas.DiaryEntryCreate) -> models.D
     return db_entry
 
 
-def get_diary_entries(db: Session, skip: int = 0, limit: int = 100) -> List[models.DiaryEntry]:
+def get_diary_entries(
+    db: Session, skip: int = 0, limit: int = 100
+) -> List[models.DiaryEntry]:
     """Return a list of diary entries ordered by newest timestamp."""
     return (
         db.query(models.DiaryEntry)
@@ -27,3 +32,13 @@ def get_diary_entries(db: Session, skip: int = 0, limit: int = 100) -> List[mode
 def get_diary_entry(db: Session, entry_id: int) -> Optional[models.DiaryEntry]:
     """Return a single diary entry by ID or None if not found."""
     return db.query(models.DiaryEntry).filter(models.DiaryEntry.id == entry_id).first()
+
+
+def get_mood_stats(db: Session) -> Dict[str, int]:
+    """Return counts of diary entries grouped by mood."""
+    results = (
+        db.query(models.DiaryEntry.mood, func.count(models.DiaryEntry.id))
+        .group_by(models.DiaryEntry.mood)
+        .all()
+    )
+    return {mood: count for mood, count in results}

--- a/app/backend_api/app/main.py
+++ b/app/backend_api/app/main.py
@@ -1,7 +1,12 @@
 # app/main.py: Aplikasi FastAPI dan endpoint-endpoint API
-from fastapi import FastAPI, Depends, HTTPException, status # Import status dan HTTPException
+from fastapi import (
+    FastAPI,
+    Depends,
+    HTTPException,
+    status,
+)  # Import status dan HTTPException
 from sqlalchemy.orm import Session
-from typing import List # Untuk tipe hint List
+from typing import List, Dict  # Untuk tipe hint List dan Dict
 
 from . import crud  # Import modul CRUD lokal
 from . import models, schemas
@@ -9,7 +14,7 @@ from .database import engine, get_db
 
 # Membuat objek FastAPI
 app = FastAPI(
-    title="Diary Depresiku API", # Judul aplikasi di Swagger UI
+    title="Diary Depresiku API",  # Judul aplikasi di Swagger UI
     description="API untuk menyimpan dan mengelola entri diary, serta fitur analisis mood.",
     version="0.1.0",
 )
@@ -18,52 +23,58 @@ app = FastAPI(
 # Ini harus dipanggil sekali saat aplikasi startup
 models.Base.metadata.create_all(bind=engine)
 
+
 # Endpoint untuk membuat entri diary baru
 @app.post(
-    "/entries/", # Menggunakan trailing slash agar konsisten dengan Android
-    response_model=schemas.DiaryEntryResponse, # Menggunakan schema respons yang benar
-    status_code=status.HTTP_201_CREATED, # Menggunakan kode status 201 Created
+    "/entries/",  # Menggunakan trailing slash agar konsisten dengan Android
+    response_model=schemas.DiaryEntryResponse,  # Menggunakan schema respons yang benar
+    status_code=status.HTTP_201_CREATED,  # Menggunakan kode status 201 Created
     summary="Membuat entri diary baru",
-    description="Menyimpan entri diary baru ke database, termasuk isi, mood, dan timestamp."
+    description="Menyimpan entri diary baru ke database, termasuk isi, mood, dan timestamp.",
 )
-async def create_diary_entry_endpoint( # Nama fungsi yang lebih deskriptif
-        entry: schemas.DiaryEntryCreate, # Schema Pydantic untuk request body
-        db: Session = Depends(get_db) # Dependency injection untuk sesi database
+async def create_diary_entry_endpoint(  # Nama fungsi yang lebih deskriptif
+    entry: schemas.DiaryEntryCreate,  # Schema Pydantic untuk request body
+    db: Session = Depends(get_db),  # Dependency injection untuk sesi database
 ):
     # Memanggil fungsi CRUD untuk membuat entri di database
     # Menggunakan properti 'content' dan 'timestamp' sesuai dengan schemas dan models
     db_entry = crud.create_diary_entry(db=db, entry=entry)
-    return db_entry # Akan otomatis dikonversi ke schema DiaryEntryResponse
+    return db_entry  # Akan otomatis dikonversi ke schema DiaryEntryResponse
+
 
 # Endpoint untuk mendapatkan semua entri diary
 @app.get(
     "/entries/",
-    response_model=List[schemas.DiaryEntryResponse], # Mengembalikan daftar DiaryEntryResponse
+    response_model=List[
+        schemas.DiaryEntryResponse
+    ],  # Mengembalikan daftar DiaryEntryResponse
     summary="Mendapatkan semua entri diary",
-    description="Mengambil daftar semua entri diary yang tersimpan, diurutkan berdasarkan timestamp terbaru."
+    description="Mengambil daftar semua entri diary yang tersimpan, diurutkan berdasarkan timestamp terbaru.",
 )
 async def read_diary_entries_endpoint(
-        skip: int = 0, # Parameter query untuk pagination
-        limit: int = 100, # Parameter query untuk pagination
-        db: Session = Depends(get_db)
+    skip: int = 0,  # Parameter query untuk pagination
+    limit: int = 100,  # Parameter query untuk pagination
+    db: Session = Depends(get_db),
 ):
     entries = crud.get_diary_entries(db=db, skip=skip, limit=limit)
     return entries
 
+
 # Endpoint untuk mendapatkan entri diary berdasarkan ID
 @app.get(
-    "/entries/{entry_id}", # Endpoint dengan path parameter
+    "/entries/{entry_id}",  # Endpoint dengan path parameter
     response_model=schemas.DiaryEntryResponse,
     summary="Mendapatkan entri diary berdasarkan ID",
-    description="Mengambil satu entri diary berdasarkan ID uniknya."
+    description="Mengambil satu entri diary berdasarkan ID uniknya.",
 )
 async def read_diary_entry_by_id_endpoint(
-        entry_id: int, # Path parameter
-        db: Session = Depends(get_db)
+    entry_id: int, db: Session = Depends(get_db)  # Path parameter
 ):
     db_entry = crud.get_diary_entry(db=db, entry_id=entry_id)
     if db_entry is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found"
+        )
     return db_entry
 
 
@@ -72,18 +83,35 @@ async def read_diary_entry_by_id_endpoint(
     "/analyze",
     response_model=schemas.AnalyzeResponse,
     summary="Menganalisis teks diary",
-    description="Melakukan analisis sederhana terhadap teks diary untuk mendeteksi mood."
+    description="Melakukan analisis sederhana terhadap teks diary untuk mendeteksi mood.",
 )
-def analyze_entry_endpoint( # Nama fungsi yang lebih deskriptif
-        request: schemas.AnalyzeRequest
+def analyze_entry_endpoint(  # Nama fungsi yang lebih deskriptif
+    request: schemas.AnalyzeRequest,
 ):
     text = request.text
     # Logika dummy: menentukan analisis berdasar kemunculan kata (hanya contoh placeholder)
     analysis_result = "Mood netral"
-    if any(word in text.lower() for word in ["sedih", "marah", "cemas", "depresi", "frustasi"]):
+    if any(
+        word in text.lower()
+        for word in ["sedih", "marah", "cemas", "depresi", "frustasi"]
+    ):
         analysis_result = "Mood terdeteksi negatif"
-    elif any(word in text.lower() for word in ["senang", "bahagia", "gembira", "ceria", "optimis"]):
+    elif any(
+        word in text.lower()
+        for word in ["senang", "bahagia", "gembira", "ceria", "optimis"]
+    ):
         analysis_result = "Mood terdeteksi positif"
 
     # Mengembalikan hasil analisis dummy
     return {"analysis": analysis_result}
+
+
+@app.get(
+    "/stats/",
+    response_model=schemas.MoodStatsResponse,
+    summary="Statistik mood",
+    description="Menghitung jumlah entri untuk tiap mood.",
+)
+async def read_mood_stats_endpoint(db: Session = Depends(get_db)):
+    stats = crud.get_mood_stats(db)
+    return {"stats": stats}

--- a/app/backend_api/app/schemas.py
+++ b/app/backend_api/app/schemas.py
@@ -1,33 +1,56 @@
 # app/schemas.py: Definisi Pydantic model untuk request dan response API
-from pydantic import BaseModel, Field # Import Field jika ingin menambahkan validasi tambahan
+from pydantic import (
+    BaseModel,
+    Field,
+)  # Import Field jika ingin menambahkan validasi tambahan
+from typing import Dict
+
 
 # Schema dasar untuk entri diary (digunakan sebagai base class untuk request/response)
 class DiaryEntryBase(BaseModel):
     # Menggunakan 'content' agar konsisten dengan model Android dan database
-    content: str = Field(..., min_length=1, max_length=5000) # Contoh validasi: minimal 1 karakter, maks 5000
+    content: str = Field(
+        ..., min_length=1, max_length=5000
+    )  # Contoh validasi: minimal 1 karakter, maks 5000
 
     # Menggunakan 'mood' dengan pilihan yang terbatas (enum bisa jadi pilihan lain)
-    mood: str = Field(..., pattern="^(Senang|Sedih|Cemas|Marah|Tersipu)$") # Contoh validasi: regex untuk pilihan mood
+    mood: str = Field(
+        ..., pattern="^(Senang|Sedih|Cemas|Marah|Tersipu)$"
+    )  # Contoh validasi: regex untuk pilihan mood
 
     # Menggunakan 'timestamp' sebagai integer (untuk Unix timestamp), konsisten dengan model Android dan database
-    timestamp: int # Tipe data int di Python setara dengan Long di Kotlin untuk angka besar
+    timestamp: (
+        int  # Tipe data int di Python setara dengan Long di Kotlin untuk angka besar
+    )
+
 
 # Schema untuk pembuatan entri (dikirim dari client/Android, tanpa ID)
 class DiaryEntryCreate(DiaryEntryBase):
     pass  # Semua field sama dengan DiaryEntryBase, karena ID dibuat otomatis oleh DB
 
+
 # Schema untuk output entri (dikembalikan ke client/Android, termasuk ID)
-class DiaryEntryResponse(DiaryEntryBase): # Mengganti 'Entry' menjadi 'DiaryEntryResponse'
-    id: int # ID entri dari database
+class DiaryEntryResponse(
+    DiaryEntryBase
+):  # Mengganti 'Entry' menjadi 'DiaryEntryResponse'
+    id: int  # ID entri dari database
 
     class Config:
         # Untuk Pydantic v2, ganti orm_mode = True menjadi from_attributes = True
-        from_attributes = True # Memungkinkan konversi otomatis dari model ORM (SQLAlchemy) ke Pydantic schema
+        from_attributes = True  # Memungkinkan konversi otomatis dari model ORM (SQLAlchemy) ke Pydantic schema
+
 
 # Schema untuk permintaan analisis AI (dummy)
 class AnalyzeRequest(BaseModel):
-    text: str = Field(..., min_length=1) # Teks yang akan dianalisis
+    text: str = Field(..., min_length=1)  # Teks yang akan dianalisis
+
 
 # Schema untuk respons analisis AI (dummy)
 class AnalyzeResponse(BaseModel):
-    analysis: str # Hasil analisis (misal: "Mood terdeteksi positif")
+    analysis: str  # Hasil analisis (misal: "Mood terdeteksi positif")
+
+
+class MoodStatsResponse(BaseModel):
+    """Response schema for mood statistics."""
+
+    stats: Dict[str, int]


### PR DESCRIPTION
## Summary
- add `get_mood_stats` in CRUD layer
- add `MoodStatsResponse` schema
- expose `/stats/` endpoint to return mood counts
- reformat backend modules

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dd523ca88324bd5772ec64f42e3c