### PR TITLE
Add mood frequency and keyword analysis

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext // Mungkin tidak langsung terpakai di sini
+import java.util.concurrent.TimeUnit
 
 /**
  * DiaryViewModel: Mengelola UI state dan berinteraksi dengan Repository untuk operasi data.
@@ -43,6 +44,32 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
     // State untuk menampung hitungan mood (Map<MoodName, Count>)
     private val _moodCounts = MutableStateFlow<Map<String, Int>>(emptyMap())
     val moodCounts: StateFlow<Map<String, Int>> = _moodCounts.asStateFlow()
+
+    // StateFlow untuk frekuensi mood mingguan dan bulanan
+    val weeklyMoodFrequency: StateFlow<Map<String, Int>> = diaryEntries
+        .map { entries -> computeMoodFrequency(entries, 7) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyMap()
+        )
+
+    val monthlyMoodFrequency: StateFlow<Map<String, Int>> = diaryEntries
+        .map { entries -> computeMoodFrequency(entries, 30) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyMap()
+        )
+
+    // Kata kunci umum untuk tiap mood dari isi entri
+    val moodKeywords: StateFlow<Map<String, List<String>>> = diaryEntries
+        .map { entries -> computeKeywords(entries) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = emptyMap()
+        )
 
     // Inisialisasi pengambilan statistik mood dari backend
     init {
@@ -83,6 +110,39 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
                 _statusMessage.value = "Gagal menyimpan entri: ${e.localizedMessage}"
                 println("Error saving entry: ${e.stackTraceToString()}") // Log error lengkap
             }
+        }
+    }
+
+    /** Hitung frekuensi mood dalam rentang hari tertentu */
+    private fun computeMoodFrequency(entries: List<DiaryEntry>, days: Int): Map<String, Int> {
+        val cutoff = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(days.toLong())
+        return entries
+            .filter { it.creationTimestamp >= cutoff }
+            .groupingBy { it.mood }
+            .eachCount()
+    }
+
+    /**
+     * Mengambil kata kunci yang paling sering muncul untuk tiap mood.
+     * Kata dengan panjang < 4 karakter diabaikan agar tidak mendominasi hasil.
+     */
+    private fun computeKeywords(entries: List<DiaryEntry>): Map<String, List<String>> {
+        val moodWordCounts = mutableMapOf<String, MutableMap<String, Int>>()
+        entries.forEach { entry ->
+            val words = entry.content
+                .lowercase()
+                .split(Regex("\\W+"))
+                .filter { it.length >= 4 }
+            val counts = moodWordCounts.getOrPut(entry.mood) { mutableMapOf() }
+            for (word in words) {
+                counts[word] = counts.getOrDefault(word, 0) + 1
+            }
+        }
+        return moodWordCounts.mapValues { (_, counts) ->
+            counts.entries
+                .sortedByDescending { it.value }
+                .take(5)
+                .map { it.key }
         }
     }
 


### PR DESCRIPTION
## Summary
- extend `DiaryViewModel` with helpers that compute mood frequency for the last week and month
- expose flows for weekly & monthly mood frequency
- parse diary content to get common keywords per mood

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug -x lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e154c8e48324a2c8746d9067540d