### PR TITLE
Add mood analysis screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.navigation.compose)
 
     // >>> PENTING: Gunakan referensi libs. untuk google-fonts
     implementation(libs.androidx.ui.text.google.fonts)

--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.diarydepresiku.ui.theme.DiarydepresikuTheme
 import com.example.diarydepresiku.ui.DiaryFormScreen // <<< PENTING: Import ini dari package ui
+import com.example.diarydepresiku.ui.MoodAnalysisScreen
+import androidx.navigation.compose.*
 
 // Hapus definisi 'moodOptions' jika sudah ada di DiaryFormScreen.kt atau tempat lain yang lebih tepat.
 // val moodOptions = listOf("Senang", "Tersipu", "Sedih", "Cemas", "Marah")
@@ -28,12 +30,51 @@ class MainActivity : ComponentActivity() {
             val diaryViewModel: DiaryViewModel = viewModel(factory = factory)
 
             DiarydepresikuTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    // Memanggil DiaryFormScreen dari file terpisah
-                    DiaryFormScreen(
-                        viewModel = diaryViewModel,
+                val navController = rememberNavController()
+                val navBackStackEntry by navController.currentBackStackEntryAsState()
+                val currentRoute = navBackStackEntry?.destination?.route
+
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    bottomBar = {
+                        NavigationBar {
+                            NavigationBarItem(
+                                selected = currentRoute == "form",
+                                onClick = {
+                                    navController.navigate("form") {
+                                        popUpTo("form") { inclusive = false }
+                                        launchSingleTop = true
+                                    }
+                                },
+                                label = { Text("Diary") },
+                                alwaysShowLabel = true
+                            )
+                            NavigationBarItem(
+                                selected = currentRoute == "analysis",
+                                onClick = {
+                                    navController.navigate("analysis") {
+                                        popUpTo("form") { inclusive = false }
+                                        launchSingleTop = true
+                                    }
+                                },
+                                label = { Text("Analysis") },
+                                alwaysShowLabel = true
+                            )
+                        }
+                    }
+                ) { innerPadding ->
+                    NavHost(
+                        navController = navController,
+                        startDestination = "form",
                         modifier = Modifier.padding(innerPadding)
-                    )
+                    ) {
+                        composable("form") {
+                            DiaryFormScreen(viewModel = diaryViewModel)
+                        }
+                        composable("analysis") {
+                            MoodAnalysisScreen(viewModel = diaryViewModel)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/diarydepresiku/ui/MoodAnalysisScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/MoodAnalysisScreen.kt
@@ -1,0 +1,92 @@
+package com.example.diarydepresiku.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.diarydepresiku.DiaryViewModel
+
+@Composable
+fun MoodAnalysisScreen(
+    viewModel: DiaryViewModel,
+    modifier: Modifier = Modifier
+) {
+    val moodCounts = viewModel.moodCounts.collectAsState().value
+    val weeklyFreq = viewModel.weeklyMoodFrequency.collectAsState().value
+    val monthlyFreq = viewModel.monthlyMoodFrequency.collectAsState().value
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Text("Mood Frequencies", style = MaterialTheme.typography.titleMedium)
+        BarChart(data = moodCounts)
+
+        Text("Weekly Mood Frequency", style = MaterialTheme.typography.titleMedium)
+        BarChart(data = weeklyFreq, barColor = MaterialTheme.colorScheme.secondary)
+
+        Text("Monthly Mood Frequency", style = MaterialTheme.typography.titleMedium)
+        BarChart(data = monthlyFreq, barColor = MaterialTheme.colorScheme.tertiary)
+    }
+}
+
+@Composable
+fun BarChart(
+    data: Map<String, Int>,
+    modifier: Modifier = Modifier,
+    barColor: Color = MaterialTheme.colorScheme.primary
+) {
+    if (data.isEmpty()) {
+        Text("No data available")
+        return
+    }
+
+    val barWidth = 40.dp
+    val spacing = 16.dp
+    val maxValue = data.values.maxOrNull() ?: 0
+
+    Column(modifier = modifier) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+        ) {
+            val barWidthPx = barWidth.toPx()
+            val spacingPx = spacing.toPx()
+            val totalChartWidth = data.size * barWidthPx + (data.size - 1) * spacingPx
+            var currentX = (size.width - totalChartWidth) / 2f
+
+            data.forEach { (_, value) ->
+                val barHeight = if (maxValue == 0) 0f else size.height * (value / maxValue.toFloat())
+                drawRect(
+                    color = barColor,
+                    topLeft = Offset(currentX, size.height - barHeight),
+                    size = Size(barWidthPx, barHeight)
+                )
+                currentX += barWidthPx + spacingPx
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(spacing)
+        ) {
+            data.forEach { (label, _) ->
+                Box(Modifier.width(barWidth), contentAlignment = Alignment.Center) {
+                    Text(label, style = MaterialTheme.typography.labelSmall)
+                }
+            }
+        }
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ room = "2.6.1"
 retrofit = "2.9.0"
 okhttp = "4.12.0"
 coroutines = "1.8.0"
+navigation = "2.7.7"
 
 
 [libraries]
@@ -38,6 +39,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-ui-text-google-fonts = { group = "androidx.compose.ui", name = "ui-text-google-fonts" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 
 # Tambahan Room, Retrofit, Coroutines (pastikan ini juga ada jika Anda menggunakannya di build.gradle.kts)
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
## Summary
- add `MoodAnalysisScreen` composable with simple bar charts
- hook up navigation using `NavigationBar` and Navigation Compose
- include navigation compose dependency

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849e5628d00832499cac35c5b6e45da