### PR TITLE
Add NewsAPI content repository

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/DiaryDatabase.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryDatabase.kt
@@ -6,6 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters // **PENTING: Import TypeConverters**
 import com.example.diarydepresiku.Converters
+import com.example.diarydepresiku.content.EducationalArticleEntity
 
 /**
  * DiaryDatabase: Kelas Room Database untuk aplikasi.
@@ -17,15 +18,18 @@ import com.example.diarydepresiku.Converters
  * @param typeConverters Mendaftarkan kelas TypeConverter untuk tipe data kustom.
  */
 @Database(
-    entities = [DiaryEntry::class],
-    version = 1, // Pastikan versi ini sesuai dengan versi database Anda
-    exportSchema = false // Atur ke true untuk produksi dan periksa file skema
+    entities = [DiaryEntry::class, EducationalArticleEntity::class],
+    version = 2,
+    exportSchema = false
 )
 @TypeConverters(Converters::class) // **PENTING: Daftarkan kelas TypeConverter di sini**
 abstract class DiaryDatabase : RoomDatabase() {
 
     // DAO (Data Access Object) untuk interaksi dengan entitas DiaryEntry
     abstract fun diaryDao(): DiaryDao
+
+    // DAO untuk artikel edukasi yang disimpan secara lokal
+    abstract fun educationalArticleDao(): com.example.diarydepresiku.content.EducationalArticleDao
 
     companion object {
         @Volatile // Memastikan variabel ini selalu up-to-date di semua thread

--- a/app/src/main/java/com/example/diarydepresiku/MyApplication.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MyApplication.kt
@@ -3,6 +3,9 @@ package com.example.diarydepresiku
 import android.app.Application
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import com.example.diarydepresiku.content.NewsApiService
+import com.example.diarydepresiku.content.EducationalArticleDao
+import com.example.diarydepresiku.content.ContentRepository
 
 class MyApplication : Application() {
 
@@ -16,10 +19,21 @@ class MyApplication : Application() {
         database.diaryDao()
     }
 
+    val articleDao: EducationalArticleDao by lazy {
+        database.educationalArticleDao()
+    }
+
     // Lazy initialization untuk Retrofit
     val retrofit: Retrofit by lazy {
         Retrofit.Builder()
             .baseUrl("http://10.0.2.2:8000/") // PASTIKAN URL INI BENAR (emulator: 10.0.2.2, device: IP lokal Anda)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    val newsRetrofit: Retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl("https://newsapi.org/")
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }
@@ -29,8 +43,16 @@ class MyApplication : Application() {
         retrofit.create(DiaryApi::class.java)
     }
 
+    val newsApi: NewsApiService by lazy {
+        newsRetrofit.create(NewsApiService::class.java)
+    }
+
     // Lazy initialization untuk Repository (menerima DAO dan API)
     val diaryRepository: DiaryRepository by lazy {
         DiaryRepository(diaryDao, diaryApi)
+    }
+
+    val contentRepository: ContentRepository by lazy {
+        ContentRepository(newsApi, articleDao, this)
     }
 }

--- a/app/src/main/java/com/example/diarydepresiku/content/ContentRepository.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/ContentRepository.kt
@@ -1,0 +1,50 @@
+package com.example.diarydepresiku.content
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.example.diarydepresiku.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ContentRepository(
+    private val api: NewsApiService,
+    private val dao: EducationalArticleDao,
+    private val context: Context
+) {
+    private fun isNetworkAvailable(): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val network = cm.activeNetwork ?: return false
+        val cap = cm.getNetworkCapabilities(network) ?: return false
+        return cap.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
+    suspend fun getArticles(apiKey: String, country: String = "us"): List<EducationalArticle> =
+        withContext(Dispatchers.IO) {
+            if (isNetworkAvailable()) {
+                try {
+                    val response = api.getTopHeadlines(apiKey, country)
+                    if (response.isSuccessful) {
+                        val articles = response.body()?.articles ?: emptyList()
+                        dao.clearAll()
+                        dao.insertArticles(articles.map { it.toEntity() })
+                        return@withContext articles
+                    }
+                } catch (_: Exception) {
+                    // fall back to cache
+                }
+            }
+            val cached = dao.getAllArticles().map { it.toModel() }
+            if (cached.isNotEmpty()) return@withContext cached
+            return@withContext loadDefaultArticles()
+        }
+
+    private fun loadDefaultArticles(): List<EducationalArticle> {
+        val input = context.resources.openRawResource(R.raw.default_articles)
+        val json = input.bufferedReader().use { it.readText() }
+        val type = object : TypeToken<List<EducationalArticle>>() {}.type
+        return Gson().fromJson(json, type)
+    }
+}

--- a/app/src/main/java/com/example/diarydepresiku/content/EducationalArticle.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/EducationalArticle.kt
@@ -1,0 +1,19 @@
+package com.example.diarydepresiku.content
+
+import com.google.gson.annotations.SerializedName
+
+/** Data class representing an article returned by NewsAPI */
+data class EducationalArticle(
+    @SerializedName("title") val title: String?,
+    @SerializedName("description") val description: String?,
+    @SerializedName("url") val url: String?,
+    @SerializedName("urlToImage") val urlToImage: String?,
+    @SerializedName("publishedAt") val publishedAt: String?
+)
+
+/** Wrapper for the NewsAPI response */
+data class NewsResponse(
+    @SerializedName("status") val status: String,
+    @SerializedName("totalResults") val totalResults: Int,
+    @SerializedName("articles") val articles: List<EducationalArticle>
+)

--- a/app/src/main/java/com/example/diarydepresiku/content/EducationalArticleDao.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/EducationalArticleDao.kt
@@ -1,0 +1,18 @@
+package com.example.diarydepresiku.content
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface EducationalArticleDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertArticles(articles: List<EducationalArticleEntity>)
+
+    @Query("SELECT * FROM educational_articles")
+    suspend fun getAllArticles(): List<EducationalArticleEntity>
+
+    @Query("DELETE FROM educational_articles")
+    suspend fun clearAll()
+}

--- a/app/src/main/java/com/example/diarydepresiku/content/EducationalArticleEntity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/EducationalArticleEntity.kt
@@ -1,0 +1,32 @@
+package com.example.diarydepresiku.content
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/** Entity used for caching articles in Room */
+@Entity(tableName = "educational_articles")
+data class EducationalArticleEntity(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @ColumnInfo(name = "title") val title: String?,
+    @ColumnInfo(name = "description") val description: String?,
+    @ColumnInfo(name = "url") val url: String?,
+    @ColumnInfo(name = "url_to_image") val urlToImage: String?,
+    @ColumnInfo(name = "published_at") val publishedAt: String?
+)
+
+fun EducationalArticleEntity.toModel(): EducationalArticle = EducationalArticle(
+    title = title,
+    description = description,
+    url = url,
+    urlToImage = urlToImage,
+    publishedAt = publishedAt
+)
+
+fun EducationalArticle.toEntity(): EducationalArticleEntity = EducationalArticleEntity(
+    title = title,
+    description = description,
+    url = url,
+    urlToImage = urlToImage,
+    publishedAt = publishedAt
+)

--- a/app/src/main/java/com/example/diarydepresiku/content/NewsApiService.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/NewsApiService.kt
@@ -1,0 +1,15 @@
+package com.example.diarydepresiku.content
+
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/** Retrofit service for fetching articles from NewsAPI */
+interface NewsApiService {
+    @GET("v2/top-headlines")
+    suspend fun getTopHeadlines(
+        @Query("apiKey") apiKey: String,
+        @Query("country") country: String = "us",
+        @Query("category") category: String = "health"
+    ): Response<NewsResponse>
+}

--- a/app/src/main/res/raw/default_articles.json
+++ b/app/src/main/res/raw/default_articles.json
@@ -1,0 +1,16 @@
+[
+  {
+    "title": "Mindfulness Basics",
+    "description": "Learn simple techniques to reduce stress and anxiety.",
+    "url": "https://example.com/mindfulness-basics",
+    "urlToImage": null,
+    "publishedAt": "2024-01-01T00:00:00Z"
+  },
+  {
+    "title": "Healthy Sleep Tips",
+    "description": "How to improve your sleep quality for better wellbeing.",
+    "url": "https://example.com/healthy-sleep",
+    "urlToImage": null,
+    "publishedAt": "2024-01-02T00:00:00Z"
+  }
+]


### PR DESCRIPTION
## Summary
- create `EducationalArticle` data model and retrofit service
- add Room entity/dao for cached articles
- update database schema and application initialization
- implement `ContentRepository` with online/offline logic
- provide default offline articles

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f1edd5548324b575fa4ef4715673