### PR TITLE
Add ContentViewModel with repository injection

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/ContentViewModel.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ContentViewModel.kt
@@ -1,0 +1,46 @@
+package com.example.diarydepresiku
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.diarydepresiku.content.ContentRepository
+import com.example.diarydepresiku.content.EducationalArticle
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel yang bertugas memuat dan menyediakan artikel edukasi.
+ * Repository disuntikkan melalui [ContentViewModelFactory].
+ * Opsional dapat memanfaatkan data mood dari [DiaryViewModel] untuk memfilter artikel.
+ */
+class ContentViewModel(
+    private val repository: ContentRepository,
+    private val diaryViewModel: DiaryViewModel? = null
+) : ViewModel() {
+
+    private val _articles = MutableStateFlow<List<EducationalArticle>>(emptyList())
+    val articles: StateFlow<List<EducationalArticle>> = _articles.asStateFlow()
+
+    /**
+     * Mengambil artikel terbaru dari repository.
+     * Jika [filterMood] diberikan atau terdapat mood dominan dari [DiaryViewModel],
+     * hasil akan difilter berdasarkan kata tersebut pada judul atau deskripsi.
+     */
+    fun refreshArticles(filterMood: String? = null) {
+        viewModelScope.launch {
+            val mood = filterMood
+                ?: diaryViewModel?.moodCounts?.value?.maxByOrNull { it.value }?.key
+            val allArticles = repository.getArticles(apiKey = "")
+            _articles.value = if (mood.isNullOrBlank()) {
+                allArticles
+            } else {
+                allArticles.filter { article ->
+                    article.title?.contains(mood, ignoreCase = true) == true ||
+                        article.description?.contains(mood, ignoreCase = true) == true
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/diarydepresiku/ContentViewModelFactory.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ContentViewModelFactory.kt
@@ -1,0 +1,22 @@
+package com.example.diarydepresiku
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.diarydepresiku.content.ContentRepository
+
+/**
+ * Factory untuk membuat instance [ContentViewModel] dengan dependency [ContentRepository].
+ */
+class ContentViewModelFactory(
+    private val repository: ContentRepository,
+    private val diaryViewModel: DiaryViewModel? = null
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(ContentViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return ContentViewModel(repository, diaryViewModel) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+

--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -20,6 +20,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.filled.Insights
+import com.example.diarydepresiku.ContentViewModel
+import com.example.diarydepresiku.ContentViewModelFactory
 
 
 // Hapus definisi 'moodOptions' jika sudah ada di DiaryFormScreen.kt atau tempat lain yang lebih tepat.
@@ -33,6 +35,15 @@ class MainActivity : ComponentActivity() {
             val application = LocalContext.current.applicationContext as MyApplication
             val factory = DiaryViewModelFactory(application = application)
             val diaryViewModel: DiaryViewModel = viewModel(factory = factory)
+
+            val contentFactory = ContentViewModelFactory(
+                repository = application.contentRepository,
+                diaryViewModel = diaryViewModel
+            )
+            val contentViewModel: ContentViewModel = viewModel(factory = contentFactory)
+            LaunchedEffect(Unit) {
+                contentViewModel.refreshArticles()
+            }
 
             DiarydepresikuTheme {
                 val navController = rememberNavController()


### PR DESCRIPTION
## Summary
- create `ContentViewModel` exposing a `StateFlow<List<EducationalArticle>>`
- add `ContentViewModelFactory` to inject `ContentRepository`
- initialize and trigger article refresh in `MainActivity`

## Testing
- `./gradlew tasks --all | head -n 20`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f4b7d3b88324908f84a2484c4dfd