### PR TITLE
Add educational content screen

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -15,11 +15,13 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.diarydepresiku.ui.theme.DiarydepresikuTheme
 import com.example.diarydepresiku.ui.DiaryFormScreen // <<< PENTING: Import ini dari package ui
 import com.example.diarydepresiku.ui.MoodAnalysisScreen
+import com.example.diarydepresiku.ui.EducationalContentScreen
 import androidx.navigation.compose.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.filled.Insights
+import androidx.compose.material.icons.filled.Article
 import com.example.diarydepresiku.ContentViewModel
 import com.example.diarydepresiku.ContentViewModelFactory
 
@@ -80,6 +82,19 @@ class MainActivity : ComponentActivity() {
                                 alwaysShowLabel = true
                             )
 
+                            NavigationBarItem(
+                                selected = currentRoute == "content",
+                                onClick = {
+                                    navController.navigate("content") {
+                                        popUpTo(navController.graph.startDestinationId) { inclusive = false }
+                                        launchSingleTop = true
+                                    }
+                                },
+                                icon = { Icon(Icons.Default.Article, contentDescription = "Content") },
+                                label = { Text("Content") },
+                                alwaysShowLabel = true
+                            )
+
                         }
                     }
                 ) { innerPadding ->
@@ -89,10 +104,19 @@ class MainActivity : ComponentActivity() {
                         modifier = Modifier.padding(innerPadding)
                     ) {
                         composable("form") {
-                            DiaryFormScreen(viewModel = diaryViewModel)
+                            DiaryFormScreen(
+                                viewModel = diaryViewModel,
+                                onNavigateToContent = { navController.navigate("content") }
+                            )
                         }
                         composable("analysis") {
-                            MoodAnalysisScreen(viewModel = diaryViewModel)
+                            MoodAnalysisScreen(
+                                viewModel = diaryViewModel,
+                                onNavigateToContent = { navController.navigate("content") }
+                            )
+                        }
+                        composable("content") {
+                            EducationalContentScreen(viewModel = contentViewModel)
                         }
                     }
                 }

--- a/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
@@ -45,7 +45,8 @@ val moodOptions = listOf("Senang", "Tersipu", "Sedih", "Cemas", "Marah")
 @Composable
 fun DiaryFormScreen(
     viewModel: DiaryViewModel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onNavigateToContent: (() -> Unit)? = null
 ) {
     var diaryText by remember { mutableStateOf("") }
     var selectedMood by remember { mutableStateOf(moodOptions[0]) }
@@ -117,6 +118,18 @@ fun DiaryFormScreen(
                 color = if (message.contains("gagal", ignoreCase = true)) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
                 modifier = Modifier.padding(top = 8.dp)
             )
+            if (!message.contains("gagal", ignoreCase = true)) {
+                onNavigateToContent?.let {
+                    Button(
+                        onClick = it,
+                        modifier = Modifier
+                            .padding(top = 8.dp)
+                            .fillMaxWidth()
+                    ) {
+                        Text("Lihat Artikel")
+                    }
+                }
+            }
         }
 
         Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/com/example/diarydepresiku/ui/EducationalContentScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/EducationalContentScreen.kt
@@ -1,0 +1,62 @@
+package com.example.diarydepresiku.ui
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.diarydepresiku.ContentViewModel
+import com.example.diarydepresiku.content.EducationalArticle
+import androidx.compose.runtime.collectAsState
+
+@Composable
+fun EducationalContentScreen(
+    viewModel: ContentViewModel,
+    modifier: Modifier = Modifier
+) {
+    val articles = viewModel.articles.collectAsState().value
+    val context = LocalContext.current
+
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        items(articles) { article ->
+            ArticleItem(article = article) { url ->
+                url?.let {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(it))
+                    context.startActivity(intent)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArticleItem(article: EducationalArticle, onOpen: (String?) -> Unit) {
+    Card(
+        modifier = Modifier
+            .padding(vertical = 8.dp)
+            .clickable { onOpen(article.url) },
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = article.title.orEmpty(), style = MaterialTheme.typography.titleMedium)
+            article.description?.let {
+                Text(text = it, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(top = 4.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/diarydepresiku/ui/MoodAnalysisScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/MoodAnalysisScreen.kt
@@ -2,6 +2,7 @@ package com.example.diarydepresiku.ui
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,7 +18,8 @@ import com.example.diarydepresiku.DiaryViewModel
 @Composable
 fun MoodAnalysisScreen(
     viewModel: DiaryViewModel,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onNavigateToContent: (() -> Unit)? = null
 ) {
     val moodCounts = viewModel.moodCounts.collectAsState().value
     val weeklyFreq = viewModel.weeklyMoodFrequency.collectAsState().value
@@ -37,6 +39,15 @@ fun MoodAnalysisScreen(
 
         Text("Monthly Mood Frequency", style = MaterialTheme.typography.titleMedium)
         BarChart(data = monthlyFreq, barColor = MaterialTheme.colorScheme.tertiary)
+
+        onNavigateToContent?.let {
+            Button(
+                onClick = it,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Lihat Artikel")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- create `EducationalContentScreen` to list articles
- add navigation item and route for content
- allow navigating to articles from diary form and mood analysis

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f6774fe48324a33008dd9b816aae