### PR TITLE
Integrate mood stats into content recommendations

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -46,6 +46,12 @@ class MainActivity : ComponentActivity() {
             LaunchedEffect(Unit) {
                 contentViewModel.refreshArticles()
             }
+            LaunchedEffect(Unit) {
+                diaryViewModel.moodCounts.collect { stats ->
+                    contentViewModel.updateMoodStats(stats)
+                    contentViewModel.refreshArticles()
+                }
+            }
 
             DiarydepresikuTheme {
                 val navController = rememberNavController()

--- a/app/src/main/java/com/example/diarydepresiku/ui/EducationalContentScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/EducationalContentScreen.kt
@@ -13,12 +13,13 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.diarydepresiku.ContentViewModel
 import com.example.diarydepresiku.content.EducationalArticle
-import androidx.compose.runtime.collectAsState
+import androidx.compose.material3.MaterialTheme
 
 @Composable
 fun EducationalContentScreen(
@@ -26,6 +27,7 @@ fun EducationalContentScreen(
     modifier: Modifier = Modifier
 ) {
     val articles = viewModel.articles.collectAsState().value
+    val highlightMood = viewModel.highlightMood.collectAsState().value
     val context = LocalContext.current
 
     LazyColumn(
@@ -34,7 +36,11 @@ fun EducationalContentScreen(
             .padding(16.dp)
     ) {
         items(articles) { article ->
-            ArticleItem(article = article) { url ->
+            val highlighted = highlightMood != null && (
+                article.title?.contains(highlightMood, ignoreCase = true) == true ||
+                    article.description?.contains(highlightMood, ignoreCase = true) == true
+            )
+            ArticleItem(article = article, isHighlighted = highlighted) { url ->
                 url?.let {
                     val intent = Intent(Intent.ACTION_VIEW, Uri.parse(it))
                     context.startActivity(intent)
@@ -45,12 +51,22 @@ fun EducationalContentScreen(
 }
 
 @Composable
-private fun ArticleItem(article: EducationalArticle, onOpen: (String?) -> Unit) {
+private fun ArticleItem(
+    article: EducationalArticle,
+    isHighlighted: Boolean,
+    onOpen: (String?) -> Unit
+) {
     Card(
         modifier = Modifier
             .padding(vertical = 8.dp)
             .clickable { onOpen(article.url) },
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        colors = CardDefaults.cardColors(
+            containerColor = if (isHighlighted) {
+                MaterialTheme.colorScheme.secondaryContainer
+            } else {
+                MaterialTheme.colorScheme.surface
+            }
+        )
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(text = article.title.orEmpty(), style = MaterialTheme.typography.titleMedium)


### PR DESCRIPTION
## Summary
- accept mood statistics in `ContentViewModel`
- highlight articles matching the dominant mood in `EducationalContentScreen`
- update `MainActivity` to pass mood stats from `DiaryViewModel`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f88468a48324883a21289851785c