### PR TITLE
Add daily reminder feature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,8 @@ dependencies {
     // ---- Kotlin Coroutines Core ----
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.datastore.preferences)
 
     // ---- Dependensi pengujian ----
     testImplementation(libs.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".MyApplication" android:allowBackup="true"

--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -22,8 +22,10 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.filled.Insights
 import androidx.compose.material.icons.filled.Article
+import androidx.compose.material.icons.filled.Settings
 import com.example.diarydepresiku.ContentViewModel
 import com.example.diarydepresiku.ContentViewModelFactory
+import com.example.diarydepresiku.ui.ReminderSettingsScreen
 
 
 // Hapus definisi 'moodOptions' jika sudah ada di DiaryFormScreen.kt atau tempat lain yang lebih tepat.
@@ -101,6 +103,19 @@ class MainActivity : ComponentActivity() {
                                 alwaysShowLabel = true
                             )
 
+                            NavigationBarItem(
+                                selected = currentRoute == "settings",
+                                onClick = {
+                                    navController.navigate("settings") {
+                                        popUpTo(navController.graph.startDestinationId) { inclusive = false }
+                                        launchSingleTop = true
+                                    }
+                                },
+                                icon = { Icon(Icons.Default.Settings, contentDescription = "Settings") },
+                                label = { Text("Settings") },
+                                alwaysShowLabel = true
+                            )
+
                         }
                     }
                 ) { innerPadding ->
@@ -123,6 +138,9 @@ class MainActivity : ComponentActivity() {
                         }
                         composable("content") {
                             EducationalContentScreen(viewModel = contentViewModel)
+                        }
+                        composable("settings") {
+                            ReminderSettingsScreen(prefs = application.reminderPreferences)
                         }
                     }
                 }

--- a/app/src/main/java/com/example/diarydepresiku/MyApplication.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MyApplication.kt
@@ -1,6 +1,10 @@
 package com.example.diarydepresiku
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
+import android.content.Context
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import com.example.diarydepresiku.content.NewsApiService
@@ -54,5 +58,26 @@ class MyApplication : Application() {
 
     val contentRepository: ContentRepository by lazy {
         ContentRepository(newsApi, articleDao, this)
+    }
+
+    val reminderPreferences: ReminderPreferences by lazy {
+        ReminderPreferences(this)
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                ReminderWorker.CHANNEL_ID,
+                "Daily Reminder",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(channel)
+        }
     }
 }

--- a/app/src/main/java/com/example/diarydepresiku/ReminderPreferences.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ReminderPreferences.kt
@@ -1,0 +1,40 @@
+package com.example.diarydepresiku
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+private val Context.dataStore by preferencesDataStore(name = "reminder_preferences")
+
+class ReminderPreferences(private val context: Context) {
+
+    private val formatter = DateTimeFormatter.ISO_LOCAL_TIME
+
+    val reminderEnabled: Flow<Boolean> =
+        context.dataStore.data.map { it[KEY_ENABLED] ?: false }
+
+    val reminderTime: Flow<LocalTime> =
+        context.dataStore.data.map {
+            it[KEY_TIME]?.let { t -> LocalTime.parse(t, formatter) } ?: LocalTime.of(8, 0)
+        }
+
+    suspend fun setReminderEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[KEY_ENABLED] = enabled }
+    }
+
+    suspend fun setReminderTime(time: LocalTime) {
+        context.dataStore.edit { it[KEY_TIME] = time.format(formatter) }
+    }
+
+    companion object {
+        private val KEY_ENABLED = booleanPreferencesKey("reminder_enabled")
+        private val KEY_TIME = stringPreferencesKey("reminder_time")
+    }
+}

--- a/app/src/main/java/com/example/diarydepresiku/ReminderWorker.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ReminderWorker.kt
@@ -1,0 +1,77 @@
+package com.example.diarydepresiku
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+
+class ReminderWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        showNotification()
+        return Result.success()
+    }
+
+    private fun showNotification() {
+        createChannel()
+        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("Daily Reminder")
+            .setContentText("Don't forget to record your mood today.")
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .build()
+        NotificationManagerCompat.from(applicationContext).notify(1001, notification)
+    }
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Daily Reminder",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            val manager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val CHANNEL_ID = "daily_reminder"
+    }
+}
+
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.util.concurrent.TimeUnit
+
+fun scheduleDailyReminder(context: Context, time: LocalTime) {
+    val now = LocalDateTime.now()
+    var next = now.withHour(time.hour).withMinute(time.minute).withSecond(0).withNano(0)
+    if (next.isBefore(now)) {
+        next = next.plusDays(1)
+    }
+    val delayMinutes = Duration.between(now, next).toMinutes()
+    val request = PeriodicWorkRequestBuilder<ReminderWorker>(1, TimeUnit.DAYS)
+        .setInitialDelay(delayMinutes, TimeUnit.MINUTES)
+        .build()
+    WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+        "daily_reminder",
+        ExistingPeriodicWorkPolicy.UPDATE,
+        request
+    )
+}
+
+fun cancelDailyReminder(context: Context) {
+    WorkManager.getInstance(context).cancelUniqueWork("daily_reminder")
+}

--- a/app/src/main/java/com/example/diarydepresiku/ui/ReminderSettingsScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/ReminderSettingsScreen.kt
@@ -1,0 +1,65 @@
+package com.example.diarydepresiku.ui
+
+import android.app.TimePickerDialog
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.diarydepresiku.ReminderPreferences
+import com.example.diarydepresiku.cancelDailyReminder
+import com.example.diarydepresiku.scheduleDailyReminder
+import kotlinx.coroutines.launch
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun ReminderSettingsScreen(
+    prefs: ReminderPreferences,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val enabled by prefs.reminderEnabled.collectAsState(initial = false)
+    val time by prefs.reminderTime.collectAsState(initial = LocalTime.of(8, 0))
+    var showPicker by remember { mutableStateOf(false) }
+
+    if (showPicker) {
+        TimePickerDialog(
+            context,
+            { _, hour: Int, minute: Int ->
+                val selected = LocalTime.of(hour, minute)
+                coroutineScope.launch { prefs.setReminderTime(selected) }
+                if (enabled) scheduleDailyReminder(context, selected)
+                showPicker = false
+            },
+            time.hour,
+            time.minute,
+            true
+        ).apply { setOnDismissListener { showPicker = false } }.show()
+    }
+
+    Column(modifier = modifier.padding(16.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "Enable Daily Reminder",
+                modifier = Modifier.weight(1f)
+            )
+            Switch(checked = enabled, onCheckedChange = { value ->
+                coroutineScope.launch { prefs.setReminderEnabled(value) }
+                if (value) {
+                    scheduleDailyReminder(context, time)
+                } else {
+                    cancelDailyReminder(context)
+                }
+            })
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = { showPicker = true }, enabled = enabled) {
+            val formatted = time.format(DateTimeFormatter.ofPattern("HH:mm"))
+            Text("Reminder Time: $formatted")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,8 @@ retrofit = "2.9.0"
 okhttp = "4.12.0"
 coroutines = "1.8.0"
 navigation = "2.7.7"
+work = "2.9.0"
+datastore = "1.1.1"
 
 
 [libraries]
@@ -40,6 +42,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-ui-text-google-fonts = { group = "androidx.compose.ui", name = "ui-text-google-fonts" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 # Tambahan Room, Retrofit, Coroutines (pastikan ini juga ada jika Anda menggunakannya di build.gradle.kts)
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
## Summary
- setup WorkManager and DataStore versions
- implement reminder worker and DataStore preferences
- add reminder settings screen with switch and time picker
- expose settings via navigation item
- create notification channel in application class
- request POST_NOTIFICATIONS permission

## Testing
- `./gradlew build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ff4db8f4832486c7f3d90a419e1d