### PR TITLE
Restrict cleartext traffic to debug builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,11 @@ android {
     }
 
     buildTypes {
+        debug {
+            manifestPlaceholders["usesCleartextTraffic"] = true
+        }
         release {
+            manifestPlaceholders["usesCleartextTraffic"] = false
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Diarydepresiku"
-        android:usesCleartextTraffic="true" tools:targetApi="31">
+        android:usesCleartextTraffic="${usesCleartextTraffic}" tools:targetApi="31">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary
- override `usesCleartextTraffic` with a manifest placeholder
- wire debug/release build types to populate the placeholder

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a018433148324bcd90f328cee6876