### PR TITLE
Add configurable BASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,33 @@ git clone https://github.com/yourusername/diary-depresiku.git
 cd diary-depresiku
 ./gradlew installDebug
 ```
+
+## Konfigurasi Build
+
+Secara default aplikasi menggunakan URL `http://10.0.2.2:8000/` untuk mengakses
+backend. Nilai ini didefinisikan di `app/build.gradle.kts` melalui `buildConfigField`:
+
+```kotlin
+defaultConfig {
+    buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000/\"")
+}
+```
+
+Anda bisa menimpa nilai tersebut pada setiap `buildType` misalnya:
+
+```kotlin
+buildTypes {
+    debug {
+        buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000/\"")
+    }
+    release {
+        buildConfigField("String", "BASE_URL", "\"https://api.example.com/\"")
+    }
+}
+```
+
+Gunakan `BuildConfig.BASE_URL` di kode Kotlin untuk memperoleh URL yang sesuai
+dengan jenis build.
 ## Kontribusi
 Kami menyambut kontribusi dari komunitas. Silakan fork repositori ini, buat branch baru, dan kirim pull request. Pedoman kontribusi tersedia di CONTRIBUTING.md.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,9 @@ android {
         versionCode = 1
         versionName = "1.0"
 
+        // Base URL for backend API
+        buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000/\"")
+
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true
@@ -46,6 +49,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         // >>> PENTING: Link ke versi compiler dari libs.versions.toml

--- a/app/src/main/java/com/example/diarydepresiku/MyApplication.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MyApplication.kt
@@ -10,6 +10,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 import com.example.diarydepresiku.content.NewsApiService
 import com.example.diarydepresiku.content.EducationalArticleDao
 import com.example.diarydepresiku.content.ContentRepository
+import com.example.diarydepresiku.BuildConfig
 
 class MyApplication : Application() {
 
@@ -30,7 +31,7 @@ class MyApplication : Application() {
     // Lazy initialization untuk Retrofit
     val retrofit: Retrofit by lazy {
         Retrofit.Builder()
-            .baseUrl("http://10.0.2.2:8000/") // PASTIKAN URL INI BENAR (emulator: 10.0.2.2, device: IP lokal Anda)
+            .baseUrl(BuildConfig.BASE_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }


### PR DESCRIPTION
## Summary
- define `BASE_URL` constant using `buildConfigField`
- enable BuildConfig generation for the app module
- use `BuildConfig.BASE_URL` in `MyApplication`
- document how to override the value per build type

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a02ec281883249040593f0f0dc03b