### PR TITLE
Update setup instructions for backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,9 @@
 ## Start the FastAPI backend
 From the project root, run:
 ```bash
-cd app/backend_api && uvicorn app.main:app --reload
+cd app/backend_api
+pip install -r requirements.txt
+uvicorn app.main:app --reload
 ```
 
 ## General guidelines

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@
 git clone https://github.com/yourusername/diary-depresiku.git
 cd diary-depresiku
 ./gradlew installDebug
+cd app/backend_api
+pip install -r requirements.txt
+uvicorn app.main:app --reload
 ```
 
 ## Konfigurasi Build


### PR DESCRIPTION
## Summary
- document backend dependency installation in README
- mention `pip install -r requirements.txt` before running `uvicorn` in AGENTS.md

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a082032c4832496b02301e9e57573