### PR TITLE
Add repository and API tests

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/content/ContentRepository.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/ContentRepository.kt
@@ -9,7 +9,7 @@ import com.example.diarydepresiku.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-class ContentRepository(
+open class ContentRepository(
     private val api: NewsApiService,
     private val dao: EducationalArticleDao,
     private val context: Context
@@ -21,7 +21,7 @@ class ContentRepository(
         return cap.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
     }
 
-    suspend fun getArticles(apiKey: String, country: String = "us"): List<EducationalArticle> =
+    open suspend fun getArticles(apiKey: String, country: String = "us"): List<EducationalArticle> =
         withContext(Dispatchers.IO) {
             if (isNetworkAvailable()) {
                 try {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,62 @@
+import sys
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+import pytest
+
+sys.path.append("app/backend_api")
+
+from app.main import app
+from app import models
+from app.database import Base, get_db
+
+@pytest.fixture
+def client():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(
+        autocommit=False, autoflush=False, bind=engine, future=True
+    )
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+
+
+def test_create_and_get_entries(client):
+    response = client.post(
+        "/entries/",
+        json={"content": "hello", "mood": "Senang", "timestamp": 1},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["content"] == "hello"
+
+    resp = client.get("/entries/")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+def test_mood_stats(client):
+    client.post(
+        "/entries/",
+        json={"content": "hi", "mood": "Sedih", "timestamp": 2},
+    )
+    client.post(
+        "/entries/",
+        json={"content": "hey", "mood": "Sedih", "timestamp": 3},
+    )
+    resp = client.get("/stats/")
+    assert resp.status_code == 200
+    assert resp.json()["stats"] == {"Sedih": 2}


### PR DESCRIPTION
## Summary
- make ContentRepository open for subclassing in tests
- add DiaryRepository unit tests
- add FastAPI endpoint tests

## Testing
- `pytest -q`
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0e3ad9fc8324b1e46c023d08a6ad