### PR TITLE
Implement mood based NewsAPI fetch

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,6 +20,8 @@ android {
 
         // Base URL for backend API
         buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000/\"")
+        // API key for fetching articles from NewsAPI
+        buildConfigField("String", "NEWS_API_KEY", "\"211a92aa3ca141c1b1c3a410235d80d7\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/example/diarydepresiku/ContentViewModel.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ContentViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.diarydepresiku.content.ContentRepository
 import com.example.diarydepresiku.content.EducationalArticle
+import com.example.diarydepresiku.BuildConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -46,19 +47,13 @@ class ContentViewModel(
                 ?: _dominantMood.value
                 ?: diaryViewModel?.moodCounts?.value?.maxByOrNull { it.value }?.key
 
-            val allArticles = repository.getArticles(apiKey = "")
-            if (mood.isNullOrBlank()) {
-                _articles.value = allArticles
-                _highlightMood.value = null
-            } else {
-                val matched = allArticles.filter { article ->
-                    article.title?.contains(mood, ignoreCase = true) == true ||
-                        article.description?.contains(mood, ignoreCase = true) == true
-                }
-                val others = allArticles.filterNot { matched.contains(it) }
-                _articles.value = matched + others
-                _highlightMood.value = mood
-            }
+            val allArticles = repository.getArticles(
+                apiKey = BuildConfig.NEWS_API_KEY,
+                query = mood
+            )
+
+            _articles.value = allArticles
+            _highlightMood.value = mood
         }
     }
 }

--- a/app/src/main/java/com/example/diarydepresiku/content/ContentRepository.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/ContentRepository.kt
@@ -21,11 +21,19 @@ open class ContentRepository(
         return cap.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
     }
 
-    open suspend fun getArticles(apiKey: String, country: String = "us"): List<EducationalArticle> =
+    open suspend fun getArticles(
+        apiKey: String,
+        country: String = "us",
+        query: String? = null
+    ): List<EducationalArticle> =
         withContext(Dispatchers.IO) {
             if (isNetworkAvailable()) {
                 try {
-                    val response = api.getTopHeadlines(apiKey, country)
+                    val response = if (!query.isNullOrBlank()) {
+                        api.searchArticles(apiKey, query)
+                    } else {
+                        api.getTopHeadlines(apiKey, country)
+                    }
                     if (response.isSuccessful) {
                         val articles = response.body()?.articles ?: emptyList()
                         dao.clearAll()

--- a/app/src/main/java/com/example/diarydepresiku/content/NewsApiService.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/NewsApiService.kt
@@ -12,4 +12,15 @@ interface NewsApiService {
         @Query("country") country: String = "us",
         @Query("category") category: String = "health"
     ): Response<NewsResponse>
+
+    /**
+     * Search articles using the NewsAPI `everything` endpoint.
+     * The [query] term is used to find relevant articles.
+     */
+    @GET("v2/everything")
+    suspend fun searchArticles(
+        @Query("apiKey") apiKey: String,
+        @Query("q") query: String,
+        @Query("sortBy") sortBy: String = "popularity"
+    ): Response<NewsResponse>
 }


### PR DESCRIPTION
## Summary
- add NEWS_API_KEY to build config
- support searching NewsAPI with `everything` endpoint
- fetch articles by mood in `ContentViewModel`

## Testing
- `pip install httpx --quiet`
- `pip install -r app/backend_api/requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a27c393f48324a9c813496a80b686