### PR TITLE
Update yellow accent color

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/theme/Color.kt
@@ -14,5 +14,5 @@ val Gray40 = Color(0xFFD5D8DC)     // Medium gray
 
 // Warna Aksen / Error
 val RedSoft = Color(0xFFEF9A9A)    // Merah pastel
-val YellowSoft = Color(0xFFFFF59D) // Kuning pastel untuk perhatian ringan
+val SoftYellow = Color(0xFFF8C471) // Kuning pastel lembut untuk aksen/peringatan
 val TextOnPrimary = Color(0xFF1B1B1B) // Teks gelap

--- a/app/src/main/java/com/example/diarydepresiku/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/theme/Theme.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.platform.LocalContext
 private val LightColorScheme = lightColorScheme(
     primary = Blue80,             // soft blue
     secondary = Green80,          // mint green
+    tertiary = SoftYellow,        // accent/warning color
     background = Gray80,          // light gray background
     surface = Color.White,
     error = RedSoft,
@@ -23,12 +24,14 @@ private val LightColorScheme = lightColorScheme(
     onSecondary = TextOnPrimary,
     onBackground = Color.Black,
     onSurface = Color.Black,
+    onTertiary = Color.Black,
     onError = Color.White
 )
 
 private val DarkColorScheme = darkColorScheme(
     primary = Blue40,
     secondary = Green40,
+    tertiary = SoftYellow,
     background = Gray40,
     surface = Gray40,
     error = RedSoft,
@@ -36,6 +39,7 @@ private val DarkColorScheme = darkColorScheme(
     onSecondary = Color.White,
     onBackground = Color.White,
     onSurface = Color.White,
+    onTertiary = Color.Black,
     onError = Color.Black
 )
 


### PR DESCRIPTION
## Summary
- replace `YellowSoft` with new `SoftYellow` tone
- use `SoftYellow` as the tertiary accent in light & dark themes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a57c5858c83248762546bef054a96