### PR TITLE
Add theme preferences for dark mode and font scale

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -59,7 +59,10 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
-            DiarydepresikuTheme {
+            val darkMode by application.reminderPreferences.darkMode.collectAsState(initial = false)
+            val fontScale by application.reminderPreferences.fontScale.collectAsState(initial = 1f)
+
+            DiarydepresikuTheme(darkTheme = darkMode, fontScale = fontScale) {
                 val navController = rememberNavController()
                 val navBackStackEntry by navController.currentBackStackEntryAsState()
                 val currentRoute = navBackStackEntry?.destination?.route

--- a/app/src/main/java/com/example/diarydepresiku/ReminderPreferences.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ReminderPreferences.kt
@@ -1,7 +1,6 @@
 package com.example.diarydepresiku
 
 import android.content.Context
-import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -25,6 +24,12 @@ class ReminderPreferences(private val context: Context) {
             it[KEY_TIME]?.let { t -> LocalTime.parse(t, formatter) } ?: LocalTime.of(8, 0)
         }
 
+    val darkMode: Flow<Boolean> =
+        context.dataStore.data.map { it[KEY_DARK_MODE] ?: false }
+
+    val fontScale: Flow<Float> =
+        context.dataStore.data.map { it[KEY_FONT_SCALE]?.toFloat() ?: 1f }
+
     suspend fun setReminderEnabled(enabled: Boolean) {
         context.dataStore.edit { it[KEY_ENABLED] = enabled }
     }
@@ -33,8 +38,18 @@ class ReminderPreferences(private val context: Context) {
         context.dataStore.edit { it[KEY_TIME] = time.format(formatter) }
     }
 
+    suspend fun setDarkMode(enabled: Boolean) {
+        context.dataStore.edit { it[KEY_DARK_MODE] = enabled }
+    }
+
+    suspend fun setFontScale(scale: Float) {
+        context.dataStore.edit { it[KEY_FONT_SCALE] = scale.toString() }
+    }
+
     companion object {
         private val KEY_ENABLED = booleanPreferencesKey("reminder_enabled")
         private val KEY_TIME = stringPreferencesKey("reminder_time")
+        private val KEY_DARK_MODE = booleanPreferencesKey("dark_mode")
+        private val KEY_FONT_SCALE = stringPreferencesKey("font_scale")
     }
 }

--- a/app/src/main/java/com/example/diarydepresiku/SplashActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/SplashActivity.kt
@@ -23,7 +23,11 @@ class SplashActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContent {
-            DiarydepresikuTheme {
+            val application = application as MyApplication
+            val darkMode by application.reminderPreferences.darkMode.collectAsState(initial = false)
+            val fontScale by application.reminderPreferences.fontScale.collectAsState(initial = 1f)
+
+            DiarydepresikuTheme(darkTheme = darkMode, fontScale = fontScale) {
                 SplashScreen {
                     startActivity(Intent(this, MainActivity::class.java))
                     finish()

--- a/app/src/main/java/com/example/diarydepresiku/ui/ReminderSettingsScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/ReminderSettingsScreen.kt
@@ -24,6 +24,8 @@ fun ReminderSettingsScreen(
     val coroutineScope = rememberCoroutineScope()
     val enabled by prefs.reminderEnabled.collectAsState(initial = false)
     val time by prefs.reminderTime.collectAsState(initial = LocalTime.of(8, 0))
+    val darkMode by prefs.darkMode.collectAsState(initial = false)
+    val fontScale by prefs.fontScale.collectAsState(initial = 1f)
     var showPicker by remember { mutableStateOf(false) }
 
     if (showPicker) {
@@ -60,6 +62,33 @@ fun ReminderSettingsScreen(
         Button(onClick = { showPicker = true }, enabled = enabled) {
             val formatted = time.format(DateTimeFormatter.ofPattern("HH:mm"))
             Text("Reminder Time: $formatted")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "Dark Mode",
+                modifier = Modifier.weight(1f)
+            )
+            Switch(checked = darkMode, onCheckedChange = { value ->
+                coroutineScope.launch { prefs.setDarkMode(value) }
+            })
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Font Size", style = MaterialTheme.typography.titleMedium)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            RadioButton(
+                selected = fontScale == 1f,
+                onClick = { coroutineScope.launch { prefs.setFontScale(1f) } }
+            )
+            Text("Normal", modifier = Modifier.padding(end = 16.dp))
+
+            RadioButton(
+                selected = fontScale > 1f,
+                onClick = { coroutineScope.launch { prefs.setFontScale(1.3f) } }
+            )
+            Text("Large")
         }
     }
 }

--- a/app/src/main/java/com/example/diarydepresiku/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/theme/Theme.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import com.example.diarydepresiku.ui.theme.scaledTypography
 
 // Skema warna pastel lembut (diambil dari Color.kt yang telah disesuaikan)
 // Color scheme using the refreshed palette defined in Color.kt
@@ -47,6 +48,7 @@ private val DarkColorScheme = darkColorScheme(
 fun DiarydepresikuTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = true,
+    fontScale: Float = 1f,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
@@ -61,7 +63,7 @@ fun DiarydepresikuTheme(
 
     MaterialTheme(
         colorScheme = colorScheme,
-        typography = Typography,
+        typography = scaledTypography(fontScale),
         content = content
     )
 }

--- a/app/src/main/java/com/example/diarydepresiku/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/theme/Type.kt
@@ -29,7 +29,7 @@ val AppFontFamily = FontFamily(
 
 // Bagian Typography tetap sama, karena ia hanya mereferensikan AppFontFamily
 // @OptIn(ExperimentalTextApi::class) // Hapus ini juga jika tidak ada TextStyle yang membutuhkannya
-val Typography = Typography(
+val AppTypography = Typography(
     displayLarge = TextStyle(
         fontFamily = AppFontFamily,
         fontWeight = FontWeight.Bold,
@@ -61,3 +61,18 @@ val Typography = Typography(
         fontSize = 14.sp
     )
 )
+
+fun scaledTypography(scale: Float): Typography {
+    if (scale == 1f) return AppTypography
+
+    fun TextStyle.scale() = copy(fontSize = (fontSize.value * scale).sp)
+
+    return Typography(
+        displayLarge = AppTypography.displayLarge.scale(),
+        titleLarge = AppTypography.titleLarge.scale(),
+        titleMedium = AppTypography.titleMedium.scale(),
+        bodyLarge = AppTypography.bodyLarge.scale(),
+        bodyMedium = AppTypography.bodyMedium.scale(),
+        labelLarge = AppTypography.labelLarge.scale()
+    )
+}


### PR DESCRIPTION
## Summary
- persist dark mode and font scale in `ReminderPreferences`
- apply font scale and theme preferences in `DiarydepresikuTheme`
- expose toggles for dark mode and font size in `ReminderSettingsScreen`
- wire theme settings into `MainActivity` and `SplashActivity`
- generate scaled typographies in `Type.kt`

## Testing
- `pip install -r app/backend_api/requirements.txt`
- `pip install httpx`
- `pytest -q`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa02ed6fc83249adf0a554b6a3945