### PR TITLE
Add offline status feedback for diary entries

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext // Mungkin tidak langsung terpakai di sini
 import java.util.concurrent.TimeUnit
+import com.example.diarydepresiku.EntryStatus
 
 /**
  * DiaryViewModel: Mengelola UI state dan berinteraksi dengan Repository untuk operasi data.
@@ -92,9 +93,12 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
         // Meluncurkan coroutine dalam viewModelScope
         viewModelScope.launch {
             try {
-                repository.addEntry(content, mood) // <<< KOREKSI: Panggil addEntry di repository
-                // Memberikan feedback sukses ke UI
-                _statusMessage.value = "Entri berhasil disimpan!"
+                val status = repository.addEntry(content, mood)
+                _statusMessage.value = if (status == EntryStatus.ONLINE) {
+                    "Entri berhasil disimpan!"
+                } else {
+                    "Entri disimpan offline"
+                }
                 // Perbarui statistik mood setelah menambah entri
                 val stats = repository.getMoodStats()
                 if (stats != null) {

--- a/app/src/main/java/com/example/diarydepresiku/EntryStatus.kt
+++ b/app/src/main/java/com/example/diarydepresiku/EntryStatus.kt
@@ -1,0 +1,10 @@
+package com.example.diarydepresiku
+
+/**
+ * Represents whether a diary entry was successfully uploaded to the server
+ * (ONLINE) or only stored locally due to a network failure (OFFLINE).
+ */
+enum class EntryStatus {
+    ONLINE,
+    OFFLINE
+}

--- a/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
@@ -2,10 +2,12 @@ package com.example.diarydepresiku.ui // Pastikan package ini sesuai dengan stru
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api // <<< PENTING: Untuk Material3 API tertentu (jika ada)
 import androidx.compose.material3.MaterialTheme
@@ -21,6 +23,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext // Diperlukan untuk Preview ViewModel
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material3.Icon
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.diarydepresiku.DiaryViewModel
 import com.example.diarydepresiku.DiaryViewModelFactory // Pastikan ini diimpor
@@ -93,20 +98,31 @@ fun DiaryFormScreen(
         }
 
         statusMessage?.let { message ->
-            Text(
-                text = message,
-                color = if (message.contains("gagal", ignoreCase = true)) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(top = 8.dp)
-            )
-            if (!message.contains("gagal", ignoreCase = true)) {
-                onNavigateToContent?.let {
-                    Button(
-                        onClick = it,
-                        modifier = Modifier
-                            .padding(top = 8.dp)
-                            .fillMaxWidth()
-                    ) {
-                        Text("Lihat Artikel")
+            if (message.contains("offline", ignoreCase = true)) {
+                Row(modifier = Modifier.padding(top = 8.dp)) {
+                    Icon(Icons.Filled.CloudOff, contentDescription = null)
+                    Spacer(Modifier.width(4.dp))
+                    Text(
+                        text = message,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            } else {
+                Text(
+                    text = message,
+                    color = if (message.contains("gagal", ignoreCase = true)) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+                if (!message.contains("gagal", ignoreCase = true)) {
+                    onNavigateToContent?.let {
+                        Button(
+                            onClick = it,
+                            modifier = Modifier
+                                .padding(top = 8.dp)
+                                .fillMaxWidth()
+                        ) {
+                            Text("Lihat Artikel")
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add `EntryStatus` enum
- return upload status from `DiaryRepository.addEntry`
- update `DiaryViewModel` to surface offline status
- show a cloud-off icon when an entry is stored offline
- expand repository tests for offline status

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa452118883248c6722713afa356d