### PR TITLE
Add privacy hint to entry screens

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/LoginActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/LoginActivity.kt
@@ -16,6 +16,10 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.example.diarydepresiku.ui.theme.SoftYellow
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.ui.Alignment
 import kotlinx.coroutines.launch
 
 class LoginActivity : ComponentActivity() {
@@ -105,6 +109,25 @@ fun LoginScreen(
         Spacer(Modifier.height(4.dp))
         TextButton(onClick = onRegister, modifier = Modifier.fillMaxWidth()) {
             Text("Register")
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .fillMaxWidth()
+        ) {
+            Icon(
+                Icons.Default.Lock,
+                contentDescription = null,
+                tint = SoftYellow
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "Privasi Anda terlindungi dengan enkripsi end-to-end.",
+                color = SoftYellow,
+                style = MaterialTheme.typography.labelSmall
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/diarydepresiku/RegisterActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/RegisterActivity.kt
@@ -11,6 +11,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
+import com.example.diarydepresiku.ui.theme.SoftYellow
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.ui.Alignment
 import kotlinx.coroutines.launch
 
 class RegisterActivity : ComponentActivity() {
@@ -59,6 +63,25 @@ fun RegisterScreen(onRegister: (String, String) -> Unit) {
         Spacer(Modifier.height(8.dp))
         Button(onClick = { onRegister(email, password) }, modifier = Modifier.fillMaxWidth()) {
             Text("Register")
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .fillMaxWidth()
+        ) {
+            Icon(
+                Icons.Default.Lock,
+                contentDescription = null,
+                tint = SoftYellow
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "Privasi Anda terlindungi dengan enkripsi end-to-end.",
+                color = SoftYellow,
+                style = MaterialTheme.typography.labelSmall
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
@@ -25,12 +25,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Icon
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.ui.Alignment
 import com.example.diarydepresiku.DiaryViewModel
 import com.example.diarydepresiku.DiaryViewModelFactory // Pastikan ini diimpor
 import com.example.diarydepresiku.MyApplication // Pastikan ini diimpor
 import com.example.diarydepresiku.ui.theme.DiarydepresikuTheme // Pastikan ini diimpor
+import com.example.diarydepresiku.ui.theme.SoftYellow
 import com.example.diarydepresiku.ui.MoodSlider
 
 import java.text.SimpleDateFormat
@@ -95,6 +98,23 @@ fun DiaryFormScreen(
             enabled = diaryText.isNotBlank()
         ) {
             Text(text = "Simpan Entri")
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(top = 4.dp)
+        ) {
+            Icon(
+                Icons.Default.Lock,
+                contentDescription = null,
+                tint = SoftYellow
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "Privasi Anda terlindungi dengan enkripsi end-to-end.",
+                color = SoftYellow,
+                style = MaterialTheme.typography.labelSmall
+            )
         }
 
         statusMessage?.let { message ->

--- a/app/src/main/java/com/example/diarydepresiku/ui/ReminderSettingsScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/ReminderSettingsScreen.kt
@@ -8,6 +8,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.example.diarydepresiku.ui.theme.SoftYellow
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
 import com.example.diarydepresiku.ReminderPreferences
 import com.example.diarydepresiku.cancelDailyReminder
 import com.example.diarydepresiku.scheduleDailyReminder
@@ -89,6 +92,25 @@ fun ReminderSettingsScreen(
                 onClick = { coroutineScope.launch { prefs.setFontScale(1.3f) } }
             )
             Text("Large")
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .fillMaxWidth()
+        ) {
+            Icon(
+                Icons.Default.Lock,
+                contentDescription = null,
+                tint = SoftYellow
+            )
+            Spacer(Modifier.width(4.dp))
+            Text(
+                text = "Privasi Anda terlindungi dengan enkripsi end-to-end.",
+                color = SoftYellow,
+                style = MaterialTheme.typography.labelSmall
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- show lock privacy hint in DiaryFormScreen
- display same privacy messaging on login, register and reminder settings screens

## Testing
- `pytest -q`
- `./gradlew lint` *(fails: Unresolved reference libs.play-services-auth)*

------
https://chatgpt.com/codex/tasks/task_e_684ab583251c8324bbb8e04774cb6636