### PR TITLE
Add name field to registration

### DIFF
--- a/app/backend_api/app/crud.py
+++ b/app/backend_api/app/crud.py
@@ -54,7 +54,9 @@ def get_user_by_email(db: Session, email: str) -> Optional[models.User]:
 
 def create_user(db: Session, user: schemas.UserCreate) -> models.User:
     hashed_password = pwd_context.hash(user.password)
-    db_user = models.User(email=user.email, hashed_password=hashed_password)
+    db_user = models.User(
+        email=user.email, name=user.name, hashed_password=hashed_password
+    )
     db.add(db_user)
     db.commit()
     db.refresh(db_user)

--- a/app/backend_api/app/main.py
+++ b/app/backend_api/app/main.py
@@ -33,7 +33,7 @@ async def register_user(user: schemas.UserCreate, db: Session = Depends(get_db))
 
 
 @app.post("/login/", response_model=schemas.Token)
-async def login_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+async def login_user(user: schemas.UserLogin, db: Session = Depends(get_db)):
     if not crud.authenticate_user(db, user.email, user.password):
         raise HTTPException(status_code=400, detail="Invalid credentials")
     return {"token": "dummy"}

--- a/app/backend_api/app/models.py
+++ b/app/backend_api/app/models.py
@@ -29,4 +29,5 @@ class User(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, unique=True, index=True, nullable=False)
+    name = Column(String, nullable=False)
     hashed_password = Column(String, nullable=False)

--- a/app/backend_api/app/schemas.py
+++ b/app/backend_api/app/schemas.py
@@ -59,6 +59,12 @@ class MoodStatsResponse(BaseModel):
 class UserCreate(BaseModel):
     email: str
     password: str
+    name: str
+
+
+class UserLogin(BaseModel):
+    email: str
+    password: str
 
 
 class Token(BaseModel):

--- a/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
@@ -37,7 +37,8 @@ data class MoodStatsResponse(
 
 data class AuthRequest(
     @SerializedName("email") val email: String,
-    @SerializedName("password") val password: String
+    @SerializedName("password") val password: String,
+    @SerializedName("name") val name: String? = null
 )
 
 data class TokenResponse(

--- a/app/src/main/java/com/example/diarydepresiku/RegisterActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/RegisterActivity.kt
@@ -25,10 +25,10 @@ class RegisterActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             DiarydepresikuTheme {
-                RegisterScreen { email, password ->
+                RegisterScreen { email, password, name ->
                     lifecycleScope.launch {
                         val api = (application as MyApplication).diaryApi
-                        val resp = api.register(AuthRequest(email, password))
+                        val resp = api.register(AuthRequest(email, password, name))
                         if (resp.isSuccessful) finish()
                     }
                 }
@@ -38,9 +38,10 @@ class RegisterActivity : ComponentActivity() {
 }
 
 @Composable
-fun RegisterScreen(onRegister: (String, String) -> Unit) {
+fun RegisterScreen(onRegister: (String, String, String) -> Unit) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf("") }
 
     Column(
         modifier = Modifier
@@ -48,6 +49,13 @@ fun RegisterScreen(onRegister: (String, String) -> Unit) {
             .padding(16.dp),
         verticalArrangement = Arrangement.Center
     ) {
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Name") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
         OutlinedTextField(
             value = email,
             onValueChange = { email = it },
@@ -63,7 +71,10 @@ fun RegisterScreen(onRegister: (String, String) -> Unit) {
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(Modifier.height(8.dp))
-        Button(onClick = { onRegister(email, password) }, modifier = Modifier.fillMaxWidth()) {
+        Button(
+            onClick = { onRegister(email, password, name) },
+            modifier = Modifier.fillMaxWidth()
+        ) {
             Text("Register")
         }
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -37,7 +37,9 @@ def client():
 
 
 def test_register_and_login(client):
-    resp = client.post("/register/", json={"email": "a@a.com", "password": "x"})
+    resp = client.post(
+        "/register/", json={"email": "a@a.com", "password": "x", "name": "Alice"}
+    )
     assert resp.status_code == 201
 
     resp = client.post("/login/", json={"email": "a@a.com", "password": "x"})
@@ -46,6 +48,6 @@ def test_register_and_login(client):
 
 
 def test_login_fail(client):
-    client.post("/register/", json={"email": "b@a.com", "password": "x"})
+    client.post("/register/", json={"email": "b@a.com", "password": "x", "name": "Bob"})
     resp = client.post("/login/", json={"email": "b@a.com", "password": "bad"})
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add `name` attribute to `UserCreate`
- update `User` model, create_user, and login schema
- send name from Android registration screen
- adjust tests for the new parameter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ad6c82ffc8324a4413e15a8f39a64