### PR TITLE
Limit nav bar routes and add settings access in profile

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -19,7 +19,6 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Settings
 
 import com.example.diarydepresiku.ui.theme.DiarydepresikuTheme
 import com.example.diarydepresiku.ui.DiaryFormScreen
@@ -120,18 +119,6 @@ class MainActivity : ComponentActivity() {
                                 label = { Text("Profile") },
                                 alwaysShowLabel = true
                             )
-                            NavigationBarItem(
-                                selected = currentRoute == "settings",
-                                onClick = {
-                                    navController.navigate("settings") {
-                                        popUpTo(navController.graph.startDestinationId) { inclusive = false }
-                                        launchSingleTop = true
-                                    }
-                                },
-                                icon = { Icon(Icons.Default.Settings, contentDescription = "Settings") },
-                                label = { Text("Settings") },
-                                alwaysShowLabel = true
-                            )
 
                         }
                     }
@@ -157,7 +144,15 @@ class MainActivity : ComponentActivity() {
                             HistoryScreen(viewModel = diaryViewModel)
                         }
                         composable("profile") {
-                            ProfileScreen(viewModel = diaryViewModel)
+                            ProfileScreen(
+                                viewModel = diaryViewModel,
+                                onNavigateToSettings = {
+                                    navController.navigate("settings") {
+                                        popUpTo(navController.graph.startDestinationId) { inclusive = false }
+                                        launchSingleTop = true
+                                    }
+                                }
+                            )
                         }
                         composable("content") {
                             EducationalContentScreen(viewModel = contentViewModel)

--- a/app/src/main/java/com/example/diarydepresiku/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/ProfileScreen.kt
@@ -3,6 +3,7 @@ package com.example.diarydepresiku.ui
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,7 +14,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun ProfileScreen(viewModel: DiaryViewModel, modifier: Modifier = Modifier) {
+fun ProfileScreen(
+    viewModel: DiaryViewModel,
+    onNavigateToSettings: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
     val achievements by viewModel.achievements.collectAsState()
     val streak by viewModel.entryStreak.collectAsState()
 
@@ -28,6 +33,11 @@ fun ProfileScreen(viewModel: DiaryViewModel, modifier: Modifier = Modifier) {
             Text(text = "Badges:", style = MaterialTheme.typography.titleMedium)
             achievements.forEach { badge ->
                 Text(text = badge.name)
+            }
+        }
+        onNavigateToSettings?.let {
+            Button(onClick = it, modifier = Modifier.padding(top = 16.dp)) {
+                Text("Settings")
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove the Settings item from the bottom navigation bar
- provide a settings button inside `ProfileScreen`

## Testing
- `pytest -q`
- `./gradlew lintFix --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684adf4d1f9083249d9c7589fd75ef74