### PR TITLE
Change FAB icon to add

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.*
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Person
@@ -77,7 +77,7 @@ class MainActivity : ComponentActivity() {
                                 }
                             }
                         ) {
-                            Icon(Icons.Filled.Edit, contentDescription = "New Entry")
+                            Icon(Icons.Default.Add, contentDescription = "New Entry")
                         }
                     },
                     floatingActionButtonPosition = FabPosition.Center,


### PR DESCRIPTION
## Summary
- update `MainActivity` to show the "add" icon instead of "edit" in the FAB

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae8252a4083248537febcc72ad2fc