### PR TITLE
Implement username persistence and greeting

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/RegisterActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/RegisterActivity.kt
@@ -27,9 +27,12 @@ class RegisterActivity : ComponentActivity() {
             DiarydepresikuTheme {
                 RegisterScreen { email, password, name ->
                     lifecycleScope.launch {
-                        val api = (application as MyApplication).diaryApi
-                        val resp = api.register(AuthRequest(email, password, name))
-                        if (resp.isSuccessful) finish()
+                        val app = application as MyApplication
+                        val resp = app.diaryApi.register(AuthRequest(email, password, name))
+                        if (resp.isSuccessful) {
+                            app.reminderPreferences.setUserName(name)
+                            finish()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/diarydepresiku/ReminderPreferences.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ReminderPreferences.kt
@@ -30,6 +30,9 @@ class ReminderPreferences(private val context: Context) {
     val fontScale: Flow<Float> =
         context.dataStore.data.map { it[KEY_FONT_SCALE]?.toFloat() ?: 1f }
 
+    val userName: Flow<String> =
+        context.dataStore.data.map { it[KEY_USER_NAME] ?: "" }
+
     suspend fun setReminderEnabled(enabled: Boolean) {
         context.dataStore.edit { it[KEY_ENABLED] = enabled }
     }
@@ -46,10 +49,15 @@ class ReminderPreferences(private val context: Context) {
         context.dataStore.edit { it[KEY_FONT_SCALE] = scale.toString() }
     }
 
+    suspend fun setUserName(name: String) {
+        context.dataStore.edit { it[KEY_USER_NAME] = name }
+    }
+
     companion object {
         private val KEY_ENABLED = booleanPreferencesKey("reminder_enabled")
         private val KEY_TIME = stringPreferencesKey("reminder_time")
         private val KEY_DARK_MODE = booleanPreferencesKey("dark_mode")
         private val KEY_FONT_SCALE = stringPreferencesKey("font_scale")
+        private val KEY_USER_NAME = stringPreferencesKey("user_name")
     }
 }

--- a/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import com.example.diarydepresiku.DiaryViewModel
 import com.example.diarydepresiku.DiaryViewModelFactory // Pastikan ini diimpor
 import com.example.diarydepresiku.MyApplication // Pastikan ini diimpor
+import com.example.diarydepresiku.ReminderPreferences
 import com.example.diarydepresiku.ui.theme.DiarydepresikuTheme // Pastikan ini diimpor
 import com.example.diarydepresiku.ui.theme.SoftYellow
 import com.example.diarydepresiku.ui.MoodSlider
@@ -56,6 +57,8 @@ fun DiaryFormScreen(
     val diaryEntries by viewModel.diaryEntries.collectAsState()
     val statusMessage by viewModel.statusMessage.collectAsState()
     val dateFormat = remember { SimpleDateFormat("dd-MM-yyyy HH:mm", Locale.getDefault()) }
+    val prefs = (LocalContext.current.applicationContext as MyApplication).reminderPreferences
+    val userName by prefs.userName.collectAsState(initial = "")
 
     Column(
         modifier = modifier
@@ -63,6 +66,12 @@ fun DiaryFormScreen(
             .fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
+        if (userName.isNotBlank()) {
+            Text(
+                text = "Halo, $userName!",
+                style = MaterialTheme.typography.titleLarge
+            )
+        }
         OutlinedTextField(
             value = diaryText,
             onValueChange = { diaryText = it },


### PR DESCRIPTION
## Summary
- persist user name in `ReminderPreferences`
- store user name after successful registration
- greet user by name on the diary form screen

## Testing
- `pip install -r app/backend_api/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae91c5af483249bd9cebaf8263901