### PR TITLE
Support activities in diary entries

### DIFF
--- a/app/backend_api/app/crud.py
+++ b/app/backend_api/app/crud.py
@@ -10,7 +10,13 @@ def create_diary_entry(
     db: Session, entry: schemas.DiaryEntryCreate
 ) -> models.DiaryEntry:
     """Create a new diary entry and persist it to the database."""
-    db_entry = models.DiaryEntry(**entry.model_dump())
+    data = entry.model_dump()
+    db_entry = models.DiaryEntry(
+        content=data["content"],
+        mood=data["mood"],
+        timestamp=data["timestamp"],
+        activities="|".join(data.get("activities", [])),
+    )
     db.add(db_entry)
     db.commit()
     db.refresh(db_entry)

--- a/app/backend_api/app/main.py
+++ b/app/backend_api/app/main.py
@@ -54,7 +54,7 @@ async def create_diary_entry_endpoint(  # Nama fungsi yang lebih deskriptif
     # Memanggil fungsi CRUD untuk membuat entri di database
     # Menggunakan properti 'content' dan 'timestamp' sesuai dengan schemas dan models
     db_entry = crud.create_diary_entry(db=db, entry=entry)
-    return db_entry  # Akan otomatis dikonversi ke schema DiaryEntryResponse
+    return schemas.DiaryEntryResponse.model_validate(db_entry)
 
 
 # Endpoint untuk mendapatkan semua entri diary
@@ -72,7 +72,7 @@ async def read_diary_entries_endpoint(
     db: Session = Depends(get_db),
 ):
     entries = crud.get_diary_entries(db=db, skip=skip, limit=limit)
-    return entries
+    return [schemas.DiaryEntryResponse.model_validate(e) for e in entries]
 
 
 # Endpoint untuk mendapatkan entri diary berdasarkan ID
@@ -90,7 +90,7 @@ async def read_diary_entry_by_id_endpoint(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="Entry not found"
         )
-    return db_entry
+    return schemas.DiaryEntryResponse.model_validate(db_entry)
 
 
 # Endpoint untuk analisis AI terhadap teks diary

--- a/app/backend_api/app/models.py
+++ b/app/backend_api/app/models.py
@@ -18,6 +18,8 @@ class DiaryEntry(Base):
     # Nama kolom untuk mood.
     mood = Column(String, nullable=False, index=True)  # Menambahkan index
 
+    activities = Column(String, nullable=False, default="")
+
     # Nama kolom untuk timestamp.
     # Menggunakan BigInteger agar dapat menyimpan nilai Long dari Android/Kotlin.
     # Harus konsisten dengan 'timestamp: int' di schemas.py dan 'creationTimestamp: Long' di DiaryEntry.kt.

--- a/app/src/main/java/com/example/diarydepresiku/Converters.kt
+++ b/app/src/main/java/com/example/diarydepresiku/Converters.kt
@@ -13,4 +13,14 @@ class Converters {
     fun dateToTimestamp(date: Date?): Long? {
         return date?.time
     }
+
+    @TypeConverter
+    fun fromActivities(value: String?): List<String> {
+        return value?.split("|")?.filter { it.isNotBlank() } ?: emptyList()
+    }
+
+    @TypeConverter
+    fun activitiesToString(list: List<String>?): String? {
+        return list?.joinToString("|")
+    }
 }

--- a/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
@@ -15,7 +15,8 @@ import retrofit2.http.*
 data class DiaryEntryRequest(
     @SerializedName("content") val content: String, // Sesuaikan dengan nama properti di backend
     @SerializedName("mood") val mood: String,
-    @SerializedName("timestamp") val timestamp: Long // Jika backend mengharapkan Unix timestamp (Long)
+    @SerializedName("timestamp") val timestamp: Long, // Jika backend mengharapkan Unix timestamp (Long)
+    @SerializedName("activities") val activities: List<String> = emptyList()
 )
 
 /**
@@ -27,6 +28,7 @@ data class DiaryEntryResponse(
     @SerializedName("content") val content: String, // Sesuaikan dengan nama properti di backend
     @SerializedName("mood") val mood: String,
     @SerializedName("timestamp") val timestamp: Long, // Jika backend mengembalikan Unix timestamp (Long)
+    @SerializedName("activities") val activities: List<String> = emptyList(),
     @SerializedName("message") val message: String? = null // Contoh properti opsional dari server
 )
 

--- a/app/src/main/java/com/example/diarydepresiku/DiaryDatabase.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryDatabase.kt
@@ -19,7 +19,7 @@ import com.example.diarydepresiku.content.EducationalArticleEntity
  */
 @Database(
     entities = [DiaryEntry::class, EducationalArticleEntity::class, Achievement::class],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 @TypeConverters(Converters::class) // **PENTING: Daftarkan kelas TypeConverter di sini**

--- a/app/src/main/java/com/example/diarydepresiku/DiaryEntry.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryEntry.kt
@@ -16,6 +16,9 @@ data class DiaryEntry(
     @ColumnInfo(name = "mood")
     val mood: String, // Mood yang dipilih untuk entri ini
 
+    @ColumnInfo(name = "activities")
+    val activities: List<String>,
+
     @ColumnInfo(name = "creation_timestamp") // Menggunakan nama kolom yang jelas
     val creationTimestamp: Long // Waktu pembuatan entri dalam bentuk Unix timestamp (Long)
 )

--- a/app/src/main/java/com/example/diarydepresiku/DiaryRepository.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryRepository.kt
@@ -13,12 +13,13 @@ class DiaryRepository(
     private val achievementDao: AchievementDao
 ) {
 
-    suspend fun addEntry(content: String, mood: String): EntryStatus {
+    suspend fun addEntry(content: String, mood: String, activities: List<String>): EntryStatus {
         val currentTimestamp = System.currentTimeMillis()
 
         val localEntry = DiaryEntry(
             content = content,
             mood = mood,
+            activities = activities,
             creationTimestamp = currentTimestamp
         )
 
@@ -31,7 +32,8 @@ class DiaryRepository(
         val remoteRequest = DiaryEntryRequest( // Membutuhkan definisi DiaryEntryRequest
             content = content,
             mood = mood,
-            timestamp = currentTimestamp
+            timestamp = currentTimestamp,
+            activities = activities
         )
 
         val status = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
@@ -122,11 +122,11 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
      * Dipanggil dari UI dengan content dan mood.
      * Menggunakan coroutine untuk menjalankan operasi I/O di background.
      */
-    fun saveEntry(content: String, mood: String) {
+    fun saveEntry(content: String, mood: String, activities: List<String>) {
         // Meluncurkan coroutine dalam viewModelScope
         viewModelScope.launch {
             try {
-                val status = repository.addEntry(content, mood)
+                val status = repository.addEntry(content, mood, activities)
                 _statusMessage.value = if (status == EntryStatus.ONLINE) {
                     "Entri berhasil disimpan!"
                 } else {

--- a/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -27,6 +28,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Icon
+import androidx.compose.material3.FilterChip
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.ui.Alignment
 import com.example.diarydepresiku.DiaryViewModel
@@ -43,6 +45,7 @@ import java.util.Locale
 
 // Daftar pilihan mood yang tersedia - Pindahkan di sini atau di file tersendiri
 val moodOptions = listOf("Senang", "Cemas", "Sedih", "Marah")
+val activityOptions = listOf("Olahraga", "Membaca", "Bersosialisasi", "Bekerja", "Meditasi")
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,6 +56,7 @@ fun DiaryFormScreen(
 ) {
     var diaryText by remember { mutableStateOf("") }
     var selectedMood by remember { mutableStateOf(moodOptions[0]) }
+    val selectedActivities = remember { mutableStateListOf<String>() }
 
     val diaryEntries by viewModel.diaryEntries.collectAsState()
     val statusMessage by viewModel.statusMessage.collectAsState()
@@ -93,14 +97,39 @@ fun DiaryFormScreen(
             modifier = Modifier.fillMaxWidth()
         )
 
+        Text(
+            text = "Aktivitas:",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            activityOptions.forEach { act ->
+                FilterChip(
+                    selected = selectedActivities.contains(act),
+                    onClick = {
+                        if (selectedActivities.contains(act)) {
+                            selectedActivities.remove(act)
+                        } else {
+                            selectedActivities.add(act)
+                        }
+                    },
+                    label = { Text(act) }
+                )
+            }
+        }
+
         Spacer(Modifier.height(16.dp))
 
         Button(
             onClick = {
                 if (diaryText.isNotBlank()) {
-                    viewModel.saveEntry(diaryText, selectedMood)
+                    viewModel.saveEntry(diaryText, selectedMood, selectedActivities.toList())
                     diaryText = ""
                     selectedMood = moodOptions[0]
+                    selectedActivities.clear()
                 }
             },
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/test/java/com/example/diarydepresiku/DiaryRepositoryTest.kt
+++ b/app/src/test/java/com/example/diarydepresiku/DiaryRepositoryTest.kt
@@ -30,7 +30,7 @@ class FakeDiaryApi : DiaryApi {
     var posted: DiaryEntryRequest? = null
     override suspend fun postEntry(entry: DiaryEntryRequest): Response<DiaryEntryResponse> {
         posted = entry
-        return Response.success(DiaryEntryResponse(1, entry.content, entry.mood, entry.timestamp))
+        return Response.success(DiaryEntryResponse(1, entry.content, entry.mood, entry.timestamp, entry.activities))
     }
     override suspend fun getMoodStats(): Response<MoodStatsResponse> {
         return Response.success(MoodStatsResponse(mapOf("Senang" to 1)))
@@ -54,10 +54,11 @@ class DiaryRepositoryTest {
         val api = FakeDiaryApi()
         val repository = DiaryRepository(dao, api, FakeAchievementDao())
 
-        val status = repository.addEntry("Hello", "Senang")
+        val status = repository.addEntry("Hello", "Senang", listOf("Bekerja"))
 
         assertEquals(1, dao.entries.size)
         assertEquals("Hello", dao.entries[0].content)
+        assertEquals(listOf("Bekerja"), dao.entries[0].activities)
         assertEquals("Senang", api.posted?.mood)
         assertEquals(EntryStatus.ONLINE, status)
     }
@@ -68,7 +69,7 @@ class DiaryRepositoryTest {
         val api = FailingDiaryApi()
         val repository = DiaryRepository(dao, api, FakeAchievementDao())
 
-        val status = repository.addEntry("Hi", "Sedih")
+        val status = repository.addEntry("Hi", "Sedih", emptyList())
 
         assertEquals(1, dao.entries.size)
         assertEquals(EntryStatus.OFFLINE, status)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,11 +39,12 @@ def client():
 def test_create_and_get_entries(client):
     response = client.post(
         "/entries/",
-        json={"content": "hello", "mood": "Senang", "timestamp": 1},
+        json={"content": "hello", "mood": "Senang", "timestamp": 1, "activities": ["A"]},
     )
     assert response.status_code == 201
     data = response.json()
     assert data["content"] == "hello"
+    assert data["activities"] == ["A"]
 
     resp = client.get("/entries/")
     assert resp.status_code == 200
@@ -53,11 +54,11 @@ def test_create_and_get_entries(client):
 def test_mood_stats(client):
     client.post(
         "/entries/",
-        json={"content": "hi", "mood": "Sedih", "timestamp": 2},
+        json={"content": "hi", "mood": "Sedih", "timestamp": 2, "activities": []},
     )
     client.post(
         "/entries/",
-        json={"content": "hey", "mood": "Sedih", "timestamp": 3},
+        json={"content": "hey", "mood": "Sedih", "timestamp": 3, "activities": []},
     )
     resp = client.get("/stats/")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- extend diary entry schema to record activities
- store and show selectable activities in DiaryFormScreen
- persist activities in DiaryRepository and Room database
- add activities to FastAPI models and crud logic
- update tests for new API schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aeb4d10ec83249eba34a8f3830d61