### PR TITLE
Add mood analysis dialog

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
@@ -47,6 +47,14 @@ data class TokenResponse(
     @SerializedName("token") val token: String
 )
 
+data class AnalyzeRequest(
+    @SerializedName("text") val text: String
+)
+
+data class AnalyzeResponse(
+    @SerializedName("analysis") val analysis: String
+)
+
 /**
  * DiaryApi: Interface Retrofit untuk berkomunikasi dengan backend FastAPI.
  * Mendefinisikan semua endpoint API yang akan digunakan aplikasi.
@@ -74,6 +82,9 @@ interface DiaryApi {
 
     @POST("login/")
     suspend fun login(@Body request: AuthRequest): Response<TokenResponse>
+
+    @POST("analyze")
+    suspend fun analyzeEntry(@Body request: AnalyzeRequest): Response<AnalyzeResponse>
 
     // (Opsional) Endpoint lain dapat didefinisikan di sini, misalnya:
     // @GET("entries/")

--- a/app/src/main/java/com/example/diarydepresiku/DiaryRepository.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryRepository.kt
@@ -95,6 +95,24 @@ class DiaryRepository(
         }
     }
 
+    suspend fun analyzeEntry(text: String): String? {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = diaryApi.analyzeEntry(AnalyzeRequest(text))
+                if (response.isSuccessful) {
+                    response.body()?.analysis
+                } else {
+                    val errorBody = response.errorBody()?.string()
+                    println("Failed to analyze entry: ${response.code()} - $errorBody")
+                    null
+                }
+            } catch (e: Exception) {
+                println("Network error analyzing entry: ${e.message}")
+                null
+            }
+        }
+    }
+
     // TODO: Tambahkan fungsi lain untuk CRUD (update, delete, getById) jika diperlukan
     // suspend fun updateEntry(entry: DiaryEntry) = withContext(Dispatchers.IO) { diaryDao.updateEntry(entry) }
     // suspend fun deleteEntry(entry: DiaryEntry) = withContext(Dispatchers.IO) { diaryDao.deleteEntry(entry) }

--- a/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
@@ -44,6 +44,9 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
     private val _statusMessage = MutableStateFlow<String?>(null)
     val statusMessage: StateFlow<String?> = _statusMessage.asStateFlow()
 
+    private val _analysisResult = MutableStateFlow<String?>(null)
+    val analysisResult: StateFlow<String?> = _analysisResult.asStateFlow()
+
     // <<< TAMBAHAN UNTUK ANALISIS MOOD >>>
     // State untuk menampung hitungan mood (Map<MoodName, Count>)
     private val _moodCounts = MutableStateFlow<Map<String, Int>>(emptyMap())
@@ -132,6 +135,7 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
                 } else {
                     "Entri disimpan offline"
                 }
+                _analysisResult.value = repository.analyzeEntry(content)
                 // Perbarui statistik mood setelah menambah entri
                 val stats = repository.getMoodStats()
                 if (stats != null) {
@@ -148,6 +152,10 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
                 println("Error saving entry: ${e.stackTraceToString()}") // Log error lengkap
             }
         }
+    }
+
+    fun clearAnalysisResult() {
+        _analysisResult.value = null
     }
 
     /** Hitung frekuensi mood dalam rentang hari tertentu */

--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -131,6 +131,7 @@ class MainActivity : ComponentActivity() {
                         composable("form") {
                             DiaryFormScreen(
                                 viewModel = diaryViewModel,
+                                contentViewModel = contentViewModel,
                                 onNavigateToContent = { navController.navigate("content") }
                             )
                         }


### PR DESCRIPTION
## Summary
- support analyzing entries via new API call
- show analysis results in a dialog with article suggestions
- refresh and open content screen from dialog
- pass ContentViewModel to `DiaryFormScreen`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684aed09d0688324a495c3424a5e7aa4