### PR TITLE
Update streak achievements

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryViewModel.kt
@@ -109,10 +109,8 @@ class DiaryViewModel(application: Application) : AndroidViewModel(application) {
             entryStreak.collect { streak ->
                 if (streak >= 30 && achievements.value.none { it.name == "30 Day Streak" }) {
                     repository.addAchievement("30 Day Streak")
-                } else if (streak >= 7 && achievements.value.none { it.name == "7 Day Streak" }) {
-                    repository.addAchievement("7 Day Streak")
-                } else if (streak >= 3 && achievements.value.none { it.name == "3 Day Streak" }) {
-                    repository.addAchievement("3 Day Streak")
+                } else if (streak >= 5 && achievements.value.none { it.name == "5 Day Streak" }) {
+                    repository.addAchievement("5 Day Streak")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- update streak achievement logic to use 5-day and 30-day thresholds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af615b1308324a404798e16579d85