### PR TITLE
Add help button on profile screen

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/ProfileScreen.kt
@@ -3,6 +3,9 @@ package com.example.diarydepresiku.ui
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -11,6 +14,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.example.diarydepresiku.DiaryViewModel
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -21,6 +25,8 @@ fun ProfileScreen(
 ) {
     val achievements by viewModel.achievements.collectAsState()
     val streak by viewModel.entryStreak.collectAsState()
+
+    val context = LocalContext.current
 
     Column(
         modifier = modifier
@@ -39,6 +45,21 @@ fun ProfileScreen(
             Button(onClick = it, modifier = Modifier.padding(top = 16.dp)) {
                 Text("Settings")
             }
+        }
+
+        Spacer(Modifier.padding(top = 24.dp))
+        Text(
+            text = "Jika Anda merasa membutuhkan bantuan profesional, Anda dapat menghubungi layanan konseling.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Button(
+            onClick = {
+                val intent = Intent(Intent.ACTION_DIAL, Uri.parse("tel:119"))
+                context.startActivity(intent)
+            },
+            modifier = Modifier.padding(top = 8.dp)
+        ) {
+            Text("Hubungi Bantuan")
         }
     }
 }


### PR DESCRIPTION
## Summary
- profile: add dialer link to professional help and add short help text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af7080d48832487ad1aaa0e923850