### PR TITLE
Add haptic feedback on user actions

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext // Diperlukan untuk Preview ViewModel
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.material.icons.Icons
@@ -61,6 +63,8 @@ fun DiaryFormScreen(
     var diaryText by remember { mutableStateOf("") }
     var selectedMood by remember { mutableStateOf(moodOptions[0]) }
     val selectedActivities = remember { mutableStateListOf<String>() }
+
+    val haptic = LocalHapticFeedback.current
 
     val diaryEntries by viewModel.diaryEntries.collectAsState()
     val statusMessage by viewModel.statusMessage.collectAsState()
@@ -139,6 +143,7 @@ fun DiaryFormScreen(
         Button(
             onClick = {
                 if (diaryText.isNotBlank()) {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                     viewModel.saveEntry(diaryText, selectedMood, selectedActivities.toList())
                     diaryText = ""
                     selectedMood = moodOptions[0]

--- a/app/src/main/java/com/example/diarydepresiku/ui/MoodSlider.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/MoodSlider.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import kotlin.math.roundToInt
@@ -26,6 +28,8 @@ fun MoodSlider(
     val emojis = listOf("😊", "😟", "😢", "😡")
     val moodNames = listOf("Senang", "Cemas", "Sedih", "Marah")
     var sliderPosition by remember { mutableFloatStateOf(moodNames.indexOf(selectedMood).coerceAtLeast(0).toFloat()) }
+
+    val haptic = LocalHapticFeedback.current
 
     LaunchedEffect(selectedMood) {
         sliderPosition = moodNames.indexOf(selectedMood).coerceAtLeast(0).toFloat()
@@ -56,6 +60,7 @@ fun MoodSlider(
                 sliderPosition = it
                 val idx = it.roundToInt().coerceIn(emojis.indices)
                 onMoodChange(moodNames[idx])
+                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
             },
             valueRange = 0f..(emojis.size - 1).toFloat(),
             steps = emojis.size - 2


### PR DESCRIPTION
## Summary
- trigger haptic feedback when saving an entry
- vibrate on mood changes from the slider

## Testing
- `python3 -m pip install -r app/backend_api/requirements.txt`
- `pytest -q`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af853f8d88324ab4a30c9ed6681de