### PR TITLE
Add scrolling to DiaryFormScreen

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api // <<< PENTING: Untuk Material3 API tertentu (jika ada)
 import androidx.compose.material3.MaterialTheme
@@ -83,6 +85,7 @@ fun DiaryFormScreen(
 
     Column(
         modifier = modifier
+            .verticalScroll(rememberScrollState())
             .padding(16.dp)
             .fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp)


### PR DESCRIPTION
## Summary
- enable scrolling on the diary form so the save button doesn't hide behind the keyboard

## Testing
- `pip install -r app/backend_api/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b1f9613208324b0c7da3f15997d86