### PR TITLE
Load API keys from local.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ buildTypes {
 
 Gunakan `BuildConfig.BASE_URL` di kode Kotlin untuk memperoleh URL yang sesuai
 dengan jenis build.
+
+### Kunci API
+
+Simpan kunci API eksternal di file `local.properties` pada direktori proyek.
+Tambahkan entri berikut:
+
+```properties
+NEWS_API_KEY=your-news-api-key
+GEMINI_API_KEY=your-gemini-api-key
+```
+
+File `local.properties` sudah ada di `.gitignore`, sehingga kunci rahasia tidak
+terikut saat commit.
 ## Kontribusi
 Kami menyambut kontribusi dari komunitas. Silakan fork repositori ini, buat branch baru, dan kirim pull request. Pedoman kontribusi tersedia di CONTRIBUTING.md.
 
@@ -148,3 +161,4 @@ Pengembang utama:
 dr. Tan
 Email: tanerizawa(at)gmail.com
 GitHub: https://github.com/tanerizawa
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,11 +1,23 @@
 // app/build.gradle.kts
 
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp) // <<< GUNAKAN ALIAS INI jika sudah didefinisikan di libs.versions.toml
 }
+
+val localProps = Properties().apply {
+    val file = rootProject.file("local.properties")
+    if (file.exists()) {
+        load(file.inputStream())
+    }
+}
+
+fun secret(key: String): String? =
+    localProps.getProperty(key) ?: project.findProperty(key) as String?
 
 android {
     namespace = "com.example.diarydepresiku"
@@ -20,8 +32,9 @@ android {
 
         // Base URL for backend API
         buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000/\"")
-        // API key for fetching articles from NewsAPI
-        buildConfigField("String", "NEWS_API_KEY", "\"211a92aa3ca141c1b1c3a410235d80d7\"")
+        // API keys loaded from local.properties or Gradle properties
+        buildConfigField("String", "NEWS_API_KEY", "\"${secret("NEWS_API_KEY") ?: ""}\"")
+        buildConfigField("String", "GEMINI_API_KEY", "\"${secret("GEMINI_API_KEY") ?: ""}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary
- load NEWS_API_KEY and GEMINI_API_KEY from `local.properties` or Gradle properties
- document how to define API keys

## Testing
- `pytest -q`
- `./gradlew lintFix` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2514c370832480d3a16d9273ca5e