### PR TITLE
Integrate Gemini for mood analysis

### DIFF
--- a/app/backend_api/requirements.txt
+++ b/app/backend_api/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy==2.0.41
 pydantic==2.11.5
 passlib[bcrypt]==1.7.4
 httpx==0.27.0
+requests==2.31.0


### PR DESCRIPTION
## Summary
- use `requests` in backend API requirements
- read `GEMINI_API_KEY` and call the Gemini model
- interpret Gemini response in `analyze_entry_endpoint`
- mock Gemini API in `tests/test_api.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b283164d08324be1d5779010c6bdf