### PR TITLE
Update README developer install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ cd diary-depresiku
 ./gradlew installDebug
 cd app/backend_api
 pip install -r requirements.txt
+export GEMINI_API_KEY=your-gemini-api-key
+uvicorn app.main:app --reload
+```
+
+Anda juga dapat menyimpan kunci di file `.env` dan memuatnya sebelum
+menjalankan backend:
+
+```bash
+echo "GEMINI_API_KEY=your-gemini-api-key" > .env
+set -a && source .env && set +a
 uvicorn app.main:app --reload
 ```
 


### PR DESCRIPTION
## Summary
- add GEMINI_API_KEY setup instructions to developer install steps
- show how to use a `.env` file

## Testing
- `pip install -r app/backend_api/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b2925e6b483248ae7fe7d654f5e8b