### PR TITLE
Add Gemini article generation endpoint

### DIFF
--- a/app/backend_api/app/schemas.py
+++ b/app/backend_api/app/schemas.py
@@ -68,6 +68,19 @@ class AnalyzeResponse(BaseModel):
     analysis: str  # Hasil analisis (misal: "Mood terdeteksi positif")
 
 
+class GeminiArticleRequest(BaseModel):
+    """Request body for generating article ideas."""
+
+    text: str = Field(..., min_length=1)
+
+
+class GeminiArticleResponse(BaseModel):
+    """Response item containing generated article data."""
+
+    title: str
+    summary: str
+
+
 class MoodStatsResponse(BaseModel):
     """Response schema for mood statistics."""
 


### PR DESCRIPTION
## Summary
- add GeminiArticleRequest and GeminiArticleResponse schemas
- generate article titles and summaries using Gemini
- expose `/gemini_articles/` endpoint
- test article generation API and error handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4ba02a7c8324afbb7fddfb94723d