### PR TITLE
Add Gemini article fetch

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
@@ -55,6 +55,10 @@ data class AnalyzeResponse(
     @SerializedName("analysis") val analysis: String
 )
 
+data class GeminiArticlesRequest(
+    @SerializedName("text") val text: String
+)
+
 /**
  * DiaryApi: Interface Retrofit untuk berkomunikasi dengan backend FastAPI.
  * Mendefinisikan semua endpoint API yang akan digunakan aplikasi.
@@ -85,6 +89,9 @@ interface DiaryApi {
 
     @POST("analyze")
     suspend fun analyzeEntry(@Body request: AnalyzeRequest): Response<AnalyzeResponse>
+
+    @POST("gemini_articles/")
+    suspend fun geminiArticles(@Body request: GeminiArticlesRequest): Response<List<com.example.diarydepresiku.content.EducationalArticle>>
 
     // (Opsional) Endpoint lain dapat didefinisikan di sini, misalnya:
     // @GET("entries/")

--- a/app/src/main/java/com/example/diarydepresiku/MyApplication.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MyApplication.kt
@@ -68,7 +68,7 @@ class MyApplication : Application() {
     }
 
     val contentRepository: ContentRepository by lazy {
-        ContentRepository(newsApi, articleDao, reactionDao, this)
+        ContentRepository(newsApi, diaryApi, articleDao, reactionDao, this)
     }
 
     val reminderPreferences: ReminderPreferences by lazy {

--- a/app/src/main/java/com/example/diarydepresiku/content/EducationalArticle.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/EducationalArticle.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 /** Data class representing an article returned by NewsAPI */
 data class EducationalArticle(
     @SerializedName("title") val title: String?,
-    @SerializedName("description") val description: String?,
+    @SerializedName(value = "description", alternate = ["summary"]) val description: String?,
     @SerializedName("url") val url: String?,
     @SerializedName("urlToImage") val urlToImage: String?,
     @SerializedName("publishedAt") val publishedAt: String?

--- a/app/src/test/java/com/example/diarydepresiku/DiaryRepositoryTest.kt
+++ b/app/src/test/java/com/example/diarydepresiku/DiaryRepositoryTest.kt
@@ -13,6 +13,12 @@ import okhttp3.ResponseBody
 
 // Status flag for uploads
 import com.example.diarydepresiku.EntryStatus
+import com.example.diarydepresiku.AuthRequest
+import com.example.diarydepresiku.TokenResponse
+import com.example.diarydepresiku.AnalyzeRequest
+import com.example.diarydepresiku.AnalyzeResponse
+import com.example.diarydepresiku.GeminiArticlesRequest
+import com.example.diarydepresiku.content.EducationalArticle
 
 class FakeDiaryDao : DiaryDao {
     val entries = mutableListOf<DiaryEntry>()
@@ -40,6 +46,12 @@ class FakeDiaryApi : DiaryApi {
     override suspend fun getMoodStats(): Response<MoodStatsResponse> {
         return Response.success(MoodStatsResponse(mapOf("Senang" to 1)))
     }
+    override suspend fun register(request: AuthRequest): Response<Unit> = Response.success(Unit)
+    override suspend fun login(request: AuthRequest): Response<TokenResponse> = Response.success(TokenResponse("token"))
+    override suspend fun analyzeEntry(request: AnalyzeRequest): Response<AnalyzeResponse> =
+        Response.success(AnalyzeResponse("ok"))
+    override suspend fun geminiArticles(request: GeminiArticlesRequest): Response<List<EducationalArticle>> =
+        Response.success(emptyList())
 }
 
 class FailingDiaryApi : DiaryApi {
@@ -50,6 +62,12 @@ class FailingDiaryApi : DiaryApi {
     override suspend fun getMoodStats(): Response<MoodStatsResponse> {
         return Response.success(MoodStatsResponse(emptyMap()))
     }
+    override suspend fun register(request: AuthRequest): Response<Unit> = Response.success(Unit)
+    override suspend fun login(request: AuthRequest): Response<TokenResponse> = Response.success(TokenResponse("token"))
+    override suspend fun analyzeEntry(request: AnalyzeRequest): Response<AnalyzeResponse> =
+        Response.success(AnalyzeResponse(""))
+    override suspend fun geminiArticles(request: GeminiArticlesRequest): Response<List<EducationalArticle>> =
+        Response.error(500, okhttp3.ResponseBody.create(null, ""))
 }
 
 class DiaryRepositoryTest {


### PR DESCRIPTION
## Summary
- add new Gemini articles request model and API
- read Gemini results when fetching content
- persist Gemini results in the local database cache
- pass DiaryApi to ContentRepository
- adjust tests for updated DiaryApi
- support both `description` and `summary` fields in articles

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4c73ea8883248c85dc3955df1dde