### PR TITLE
Add integrated home screen

### DIFF
--- a/app/src/androidTest/java/com/example/diarydepresiku/HomeScreenTest.kt
+++ b/app/src/androidTest/java/com/example/diarydepresiku/HomeScreenTest.kt
@@ -1,0 +1,17 @@
+package com.example.diarydepresiku
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.assertIsDisplayed
+import org.junit.Rule
+import org.junit.Test
+
+class HomeScreenTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun defaultArticlesShownOnHome() {
+        composeRule.onNodeWithText("Mindfulness Basics").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -22,7 +22,7 @@ import androidx.compose.material.icons.filled.Person
 
 import com.example.diarydepresiku.ui.theme.DiarydepresikuTheme
 import com.example.diarydepresiku.ui.DiaryFormScreen
-import com.example.diarydepresiku.ui.MoodAnalysisScreen
+import com.example.diarydepresiku.ui.HomeScreen
 import com.example.diarydepresiku.ui.EducationalContentScreen
 import com.example.diarydepresiku.ui.HistoryScreen
 import com.example.diarydepresiku.ui.ProfileScreen
@@ -136,9 +136,9 @@ class MainActivity : ComponentActivity() {
                             )
                         }
                         composable("home") {
-                            MoodAnalysisScreen(
-                                viewModel = diaryViewModel,
-                                onNavigateToContent = { navController.navigate("content") }
+                            HomeScreen(
+                                diaryViewModel = diaryViewModel,
+                                contentViewModel = contentViewModel
                             )
                         }
                         composable("history") {

--- a/app/src/main/java/com/example/diarydepresiku/ui/EducationalContentScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/EducationalContentScreen.kt
@@ -25,6 +25,14 @@ fun EducationalContentScreen(
     viewModel: ContentViewModel,
     modifier: Modifier = Modifier
 ) {
+    ArticleList(viewModel = viewModel, modifier = modifier)
+}
+
+@Composable
+fun ArticleList(
+    viewModel: ContentViewModel,
+    modifier: Modifier = Modifier
+) {
     val articles = viewModel.articles.collectAsState().value
     val highlightMood = viewModel.highlightMood.collectAsState().value
     val context = LocalContext.current
@@ -61,7 +69,7 @@ fun EducationalContentScreen(
 }
 
 @Composable
-private fun ArticleItem(
+fun ArticleItem(
     article: EducationalArticle,
     isHighlighted: Boolean,
     showReactions: Boolean,

--- a/app/src/main/java/com/example/diarydepresiku/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/HomeScreen.kt
@@ -1,0 +1,54 @@
+package com.example.diarydepresiku.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.diarydepresiku.ContentViewModel
+import com.example.diarydepresiku.DiaryViewModel
+
+@Composable
+fun HomeScreen(
+    diaryViewModel: DiaryViewModel,
+    contentViewModel: ContentViewModel,
+    modifier: Modifier = Modifier
+) {
+    LaunchedEffect(Unit) { contentViewModel.refreshArticles() }
+
+    val moodCounts = diaryViewModel.moodCounts.collectAsState().value
+    val weeklyFreq = diaryViewModel.weeklyMoodFrequency.collectAsState().value
+    val monthlyFreq = diaryViewModel.monthlyMoodFrequency.collectAsState().value
+    val analysis = diaryViewModel.analysisResult.collectAsState().value
+
+    LaunchedEffect(analysis) {
+        analysis?.let { contentViewModel.refreshArticles(filterMood = it) }
+    }
+
+    Column(
+        modifier = modifier
+            .verticalScroll(rememberScrollState())
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        Text("Mood Frequencies", style = MaterialTheme.typography.titleMedium)
+        BarChart(data = moodCounts)
+
+        Text("Weekly Mood Frequency", style = MaterialTheme.typography.titleMedium)
+        BarChart(data = weeklyFreq, barColor = MaterialTheme.colorScheme.secondary)
+
+        Text("Monthly Mood Frequency", style = MaterialTheme.typography.titleMedium)
+        BarChart(data = monthlyFreq, barColor = MaterialTheme.colorScheme.tertiary)
+
+        ArticleList(viewModel = contentViewModel)
+    }
+}


### PR DESCRIPTION
## Summary
- combine mood graphs and articles using new `HomeScreen`
- expose `ArticleList` composable so `HomeScreen` can reuse it
- hook `HomeScreen` into navigation
- add Compose UI test checking articles on home screen

## Testing
- `pytest -q`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b5ae6d0d88324a43eb92295dbf2e9