### PR TITLE
Update render config to use env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ GEMINI_API_KEY=your-gemini-api-key
 
 File `local.properties` sudah ada di `.gitignore`, sehingga kunci rahasia tidak
 terikut saat commit.
+
+## Deployment di Render
+
+Blueprint `render.yaml` tidak menyertakan nilai `GEMINI_API_KEY`. Saat menyiapkan layanan di Render, buka menu **Environment** dan tambahkan variabel ini dengan kunci Gemini Anda. Setelah disimpan, deploy blueprint seperti biasa.
 ## Kontribusi
 Kami menyambut kontribusi dari komunitas. Silakan fork repositori ini, buat branch baru, dan kirim pull request. Pedoman kontribusi tersedia di CONTRIBUTING.md.
 

--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     startCommand: uvicorn app.main:app --host 0.0.0.0 --port 10000
     envVars:
       - key: GEMINI_API_KEY
-        value: AIzaSyD7lc7b19kB4aYlW4e8ryt6i1mh3FnbO5Q
+        sync: false
     plan: free
     region: oregon
     buildFilter:


### PR DESCRIPTION
## Summary
- read GEMINI key from Render environment instead of hardcoding
- document how to set GEMINI_API_KEY when deploying on Render

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b62f6933c83248b4c9d9cc6482e0d