### PR TITLE
Fix tests leaving stray DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,8 @@ __pycache__/
 .pytest_cache/
 
 # Database files (FastAPI/SQLAlchemy)
-*.db                      # e.g., diary.db (this will ignore any .db file in your project root, be careful if you have other dbs you want to track)
-!app/backend_api/app/diary.db  # Example: UNCOMMENT AND ADJUST if you want to track a specific database file
+# Ignore the default SQLite database used by the API
+diary.db
 # OR: If your FastAPI database file is always named `diary.db` and you want to track it only there:
 #!backend/app/diary.db # If your backend is `app/backend/` as per your latest structure
 #!backend_api/app/diary.db # If your backend is `app/backend_api/app/` as per recommended structure

--- a/app/backend_api/app/database.py
+++ b/app/backend_api/app/database.py
@@ -2,11 +2,16 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session  # Import Session untuk tipe hint
+import os
 
 # URL database. Untuk SQLite, ini adalah path ke file database.
-# Database akan dibuat di root direktori aplikasi FastAPI.
-# Catatan: "sqlite:///./diary.db" berarti file diary.db ada di direktori yang sama dengan tempat Anda menjalankan server.
-SQLALCHEMY_DATABASE_URL = "sqlite:///./diary.db"
+# Database akan dibuat di root direktori aplikasi FastAPI kecuali jika
+# variabel lingkungan ``SQLALCHEMY_DATABASE_URL`` didefinisikan.
+# Catatan: "sqlite:///./diary.db" berarti file diary.db ada di direktori yang
+# sama dengan tempat Anda menjalankan server.
+SQLALCHEMY_DATABASE_URL = os.getenv(
+    "SQLALCHEMY_DATABASE_URL", "sqlite:///./diary.db"
+)
 
 # create_engine membuat instance engine database.
 # - connect_args={"check_same_thread": False}: Diperlukan untuk SQLite

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,12 +1,13 @@
 import sys
-from fastapi.testclient import TestClient
 import os
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 import pytest
 import requests
 
+os.environ["SQLALCHEMY_DATABASE_URL"] = "sqlite:///:memory:"
 sys.path.append("app/backend_api")
 
 from app.main import app

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,12 @@
 import sys
+import os
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
+os.environ["SQLALCHEMY_DATABASE_URL"] = "sqlite:///:memory:"
 sys.path.append("app/backend_api")
 
 from app.main import app


### PR DESCRIPTION
## Summary
- ignore `diary.db`
- allow overriding SQLALCHEMY_DATABASE_URL via env var
- use in-memory DB for tests to avoid leftover files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b6315cc1c8324bb456176f11b7f6a