### PR TITLE
Fix nested scroll issue with ArticleList

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/ui/EducationalContentScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/EducationalContentScreen.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -20,12 +18,17 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.example.diarydepresiku.ContentViewModel
 import com.example.diarydepresiku.content.EducationalArticle
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 @Composable
 fun EducationalContentScreen(
     viewModel: ContentViewModel,
     modifier: Modifier = Modifier
 ) {
-    ArticleList(viewModel = viewModel, modifier = modifier)
+    ArticleList(
+        viewModel = viewModel,
+        modifier = modifier.verticalScroll(rememberScrollState())
+    )
 }
 
 @Composable
@@ -38,12 +41,12 @@ fun ArticleList(
     val context = LocalContext.current
     var openedUrl by remember { mutableStateOf<String?>(null) }
 
-    LazyColumn(
+    Column(
         modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        items(articles) { article ->
+        articles.forEach { article ->
             val highlighted = highlightMood != null && (
                 article.title?.contains(highlightMood, ignoreCase = true) == true ||
                     article.description?.contains(highlightMood, ignoreCase = true) == true

--- a/app/src/main/java/com/example/diarydepresiku/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/HomeScreen.kt
@@ -4,8 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -33,22 +32,32 @@ fun HomeScreen(
         analysis?.let { contentViewModel.refreshArticles(filterMood = it) }
     }
 
-    Column(
+    LazyColumn(
         modifier = modifier
-            .verticalScroll(rememberScrollState())
             .fillMaxSize()
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp)
     ) {
-        Text("Mood Frequencies", style = MaterialTheme.typography.titleMedium)
-        BarChart(data = moodCounts)
-
-        Text("Weekly Mood Frequency", style = MaterialTheme.typography.titleMedium)
-        BarChart(data = weeklyFreq, barColor = MaterialTheme.colorScheme.secondary)
-
-        Text("Monthly Mood Frequency", style = MaterialTheme.typography.titleMedium)
-        BarChart(data = monthlyFreq, barColor = MaterialTheme.colorScheme.tertiary)
-
-        ArticleList(viewModel = contentViewModel)
+        item {
+            Column {
+                Text("Mood Frequencies", style = MaterialTheme.typography.titleMedium)
+                BarChart(data = moodCounts)
+            }
+        }
+        item {
+            Column {
+                Text("Weekly Mood Frequency", style = MaterialTheme.typography.titleMedium)
+                BarChart(data = weeklyFreq, barColor = MaterialTheme.colorScheme.secondary)
+            }
+        }
+        item {
+            Column {
+                Text("Monthly Mood Frequency", style = MaterialTheme.typography.titleMedium)
+                BarChart(data = monthlyFreq, barColor = MaterialTheme.colorScheme.tertiary)
+            }
+        }
+        item {
+            ArticleList(viewModel = contentViewModel)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- avoid nested scrolls by letting `EducationalContentScreen` add the scroll container
- remove lazy list inside `ArticleList`
- use a single `LazyColumn` in `HomeScreen`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b735059788324adcdd5acbde73b6b