### PR TITLE
Remove Gemini integration in favor of OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,11 @@ pip install -r requirements.txt
 
 ### Environment Variables
 
-Backend membutuhkan `GEMINI_API_KEY` dan `OPENROUTER_API_KEY`. Simpan keduanya di
+Backend membutuhkan `OPENROUTER_API_KEY`. Simpan variabel ini di
 file `.env` lalu muat sebelum menjalankan server:
 
 ```bash
-echo "GEMINI_API_KEY=your-gemini-api-key" > .env
-echo "OPENROUTER_API_KEY=your-openrouter-api-key" >> .env
+echo "OPENROUTER_API_KEY=your-openrouter-api-key" > .env
 set -a && source .env && set +a
 uvicorn app.main:app --reload
 ```
@@ -156,7 +155,6 @@ Tambahkan entri berikut:
 
 ```properties
 NEWS_API_KEY=your-news-api-key
-GEMINI_API_KEY=your-gemini-api-key
 OPENROUTER_API_KEY=your-openrouter-api-key
 ```
 
@@ -165,7 +163,7 @@ terikut saat commit.
 
 ## Deployment di Render
 
-Blueprint `render.yaml` tidak menyertakan kunci API. Tambahkan `GEMINI_API_KEY` dan, bila diperlukan, `OPENROUTER_API_KEY` pada menu **Environment** sebelum melakukan deploy.
+Blueprint `render.yaml` tidak menyertakan kunci API. Tambahkan `OPENROUTER_API_KEY` pada menu **Environment** sebelum melakukan deploy.
 ## Kontribusi
 Kami menyambut kontribusi dari komunitas. Silakan fork repositori ini, buat branch baru, dan kirim pull request. Pedoman kontribusi tersedia di CONTRIBUTING.md.
 

--- a/app/backend_api/app/ai_utils.py
+++ b/app/backend_api/app/ai_utils.py
@@ -7,43 +7,6 @@ from typing import List
 from . import schemas
 
 
-def analyze_with_gemini(text: str) -> str:
-    api_key = os.getenv("GEMINI_API_KEY")
-    if not api_key:
-        raise RuntimeError("Missing GEMINI_API_KEY")
-    url = (
-        "https://generativelanguage.googleapis.com/v1beta/models/"
-        f"gemini-pro:generateContent?key={api_key}"
-    )
-    payload = {
-        "contents": [
-            {
-                "parts": [
-                    {
-                        "text": (
-                            "Analisis mood untuk teks berikut secara singkat. "
-                            "Balas hanya dengan kata Positif, Negatif, atau Netral.\n"
-                            + text
-                        )
-                    }
-                ]
-            }
-        ]
-    }
-    try:
-        response = requests.post(url, json=payload, timeout=10)
-        response.raise_for_status()
-        data = response.json()
-        result = data["candidates"][0]["content"]["parts"][0]["text"].lower()
-        if "positif" in result:
-            return "Mood terdeteksi positif"
-        if "negatif" in result:
-            return "Mood terdeteksi negatif"
-        return "Mood netral"
-    except Exception as e:
-        raise RuntimeError(f"Error from Gemini API: {e}")
-
-
 async def caption_image_with_openrouter(image_url: str) -> str:
     """Return a text description of the image using OpenRouter."""
 
@@ -83,37 +46,43 @@ async def caption_image_with_openrouter(image_url: str) -> str:
         raise RuntimeError(f"Error from OpenRouter API: {e}")
 
 
-def generate_articles_with_gemini(text: str) -> List[schemas.GeminiArticleResponse]:
-    """Request Gemini API to create article titles and summaries."""
+def generate_articles_with_openrouter(text: str) -> List[schemas.ArticleResponse]:
+    """Request OpenRouter API to create article titles and summaries."""
 
-    api_key = os.getenv("GEMINI_API_KEY")
+    api_key = os.getenv("OPENROUTER_API_KEY")
     if not api_key:
-        raise RuntimeError("Missing GEMINI_API_KEY")
-    url = (
-        "https://generativelanguage.googleapis.com/v1beta/models/"
-        f"gemini-pro:generateContent?key={api_key}"
-    )
+        raise RuntimeError("Missing OPENROUTER_API_KEY")
+
     payload = {
-        "contents": [
+        "model": "google/gemini-2.0-flash-exp:free",
+        "messages": [
             {
-                "parts": [
-                    {
-                        "text": (
-                            "Buat tiga judul artikel beserta ringkasan singkat dalam format JSON "
-                            "[{'title': 'Judul', 'summary': 'Ringkasan'}] berdasarkan teks berikut.\n"
-                            + text
-                        )
-                    }
-                ]
+                "role": "user",
+                "content": (
+                    "Buat tiga judul artikel beserta ringkasan singkat dalam format JSON "
+                    "[{'title': 'Judul', 'summary': 'Ringkasan'}] berdasarkan teks berikut.\n"
+                    + text
+                ),
             }
-        ]
+        ],
     }
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
     try:
-        response = requests.post(url, json=payload, timeout=10)
+        response = requests.post(
+            "https://openrouter.ai/api/v1/chat/completions",
+            headers=headers,
+            json=payload,
+            timeout=10,
+        )
         response.raise_for_status()
         data = response.json()
-        text_resp = data["candidates"][0]["content"]["parts"][0]["text"]
+        text_resp = data["choices"][0]["message"]["content"]
         articles = json.loads(text_resp)
-        return [schemas.GeminiArticleResponse(**a) for a in articles]
+        return [schemas.ArticleResponse(**a) for a in articles]
     except Exception as e:
-        raise RuntimeError(f"Error from Gemini API: {e}")
+        raise RuntimeError(f"Error from OpenRouter API: {e}")

--- a/app/backend_api/app/schemas.py
+++ b/app/backend_api/app/schemas.py
@@ -68,13 +68,13 @@ class AnalyzeResponse(BaseModel):
     analysis: str  # Hasil analisis (misal: "Mood terdeteksi positif")
 
 
-class GeminiArticleRequest(BaseModel):
+class ArticleRequest(BaseModel):
     """Request body for generating article ideas."""
 
     text: str = Field(..., min_length=1)
 
 
-class GeminiArticleResponse(BaseModel):
+class ArticleResponse(BaseModel):
     """Response item containing generated article data."""
 
     title: str

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,7 +34,6 @@ android {
         buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000/\"")
         // API keys loaded from local.properties or Gradle properties
         buildConfigField("String", "NEWS_API_KEY", "\"${secret("NEWS_API_KEY") ?: ""}\"")
-        buildConfigField("String", "GEMINI_API_KEY", "\"${secret("GEMINI_API_KEY") ?: ""}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
+++ b/app/src/main/java/com/example/diarydepresiku/DiaryApi.kt
@@ -55,7 +55,7 @@ data class AnalyzeResponse(
     @SerializedName("analysis") val analysis: String
 )
 
-data class GeminiArticlesRequest(
+data class ArticlesRequest(
     @SerializedName("text") val text: String
 )
 
@@ -87,11 +87,11 @@ interface DiaryApi {
     @POST("login/")
     suspend fun login(@Body request: AuthRequest): Response<TokenResponse>
 
-    @POST("analyze")
+    @POST("analyze/")
     suspend fun analyzeEntry(@Body request: AnalyzeRequest): Response<AnalyzeResponse>
 
-    @POST("gemini_articles/")
-    suspend fun geminiArticles(@Body request: GeminiArticlesRequest): Response<List<com.example.diarydepresiku.content.EducationalArticle>>
+    @POST("articles/")
+    suspend fun openrouterArticles(@Body request: ArticlesRequest): Response<List<com.example.diarydepresiku.content.EducationalArticle>>
 
     // (Opsional) Endpoint lain dapat didefinisikan di sini, misalnya:
     // @GET("entries/")

--- a/app/src/main/java/com/example/diarydepresiku/content/ContentRepository.kt
+++ b/app/src/main/java/com/example/diarydepresiku/content/ContentRepository.kt
@@ -34,11 +34,11 @@ open class ContentRepository(
             if (isNetworkAvailable()) {
                 if (!query.isNullOrBlank()) {
                     try {
-                        val gemini = diaryApi.geminiArticles(
-                            com.example.diarydepresiku.GeminiArticlesRequest(query)
+                        val aiResp = diaryApi.openrouterArticles(
+                            com.example.diarydepresiku.ArticlesRequest(query)
                         )
-                        if (gemini.isSuccessful) {
-                            val articles = gemini.body() ?: emptyList()
+                        if (aiResp.isSuccessful) {
+                            val articles = aiResp.body() ?: emptyList()
                             dao.clearAll()
                             dao.insertArticles(articles.map { it.toEntity() })
                             return@withContext articles

--- a/app/src/test/java/com/example/diarydepresiku/DiaryRepositoryTest.kt
+++ b/app/src/test/java/com/example/diarydepresiku/DiaryRepositoryTest.kt
@@ -17,7 +17,7 @@ import com.example.diarydepresiku.AuthRequest
 import com.example.diarydepresiku.TokenResponse
 import com.example.diarydepresiku.AnalyzeRequest
 import com.example.diarydepresiku.AnalyzeResponse
-import com.example.diarydepresiku.GeminiArticlesRequest
+import com.example.diarydepresiku.ArticlesRequest
 import com.example.diarydepresiku.content.EducationalArticle
 
 class FakeDiaryDao : DiaryDao {
@@ -50,7 +50,7 @@ class FakeDiaryApi : DiaryApi {
     override suspend fun login(request: AuthRequest): Response<TokenResponse> = Response.success(TokenResponse("token"))
     override suspend fun analyzeEntry(request: AnalyzeRequest): Response<AnalyzeResponse> =
         Response.success(AnalyzeResponse("ok"))
-    override suspend fun geminiArticles(request: GeminiArticlesRequest): Response<List<EducationalArticle>> =
+    override suspend fun openrouterArticles(request: ArticlesRequest): Response<List<EducationalArticle>> =
         Response.success(emptyList())
 }
 
@@ -66,7 +66,7 @@ class FailingDiaryApi : DiaryApi {
     override suspend fun login(request: AuthRequest): Response<TokenResponse> = Response.success(TokenResponse("token"))
     override suspend fun analyzeEntry(request: AnalyzeRequest): Response<AnalyzeResponse> =
         Response.success(AnalyzeResponse(""))
-    override suspend fun geminiArticles(request: GeminiArticlesRequest): Response<List<EducationalArticle>> =
+    override suspend fun openrouterArticles(request: ArticlesRequest): Response<List<EducationalArticle>> =
         Response.error(500, okhttp3.ResponseBody.create(null, ""))
 }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -80,45 +80,41 @@ def test_analyze_entry(client, monkeypatch):
             pass
 
         def json(self):
-            return {"candidates": [{"content": {"parts": [{"text": "Positif"}]}}]}
+            return {"choices": [{"message": {"content": "Positif"}}]}
 
-    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
-    monkeypatch.setattr("app.ai_utils.requests.post", lambda *a, **k: MockResp())
-    resp = client.post("/analyze", json={"text": "saya senang"})
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dummy")
+    monkeypatch.setattr("app.openrouter.requests.post", lambda *a, **k: MockResp())
+    resp = client.post("/analyze/", json={"text": "saya senang"})
     assert resp.status_code == 200
-    assert resp.json()["analysis"] == "Mood terdeteksi positif"
+    assert resp.json()["analysis"] == "Positif"
 
 
-def test_gemini_articles(client, monkeypatch):
+def test_openrouter_articles(client, monkeypatch):
     class MockResp:
         def raise_for_status(self):
             pass
 
         def json(self):
             return {
-                "candidates": [
-                    {
-                        "content": {
-                            "parts": [{"text": '[{"title": "A", "summary": "B"}]'}]
-                        }
-                    }
+                "choices": [
+                    {"message": {"content": '[{"title": "A", "summary": "B"}]'}}
                 ]
             }
 
-    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dummy")
     monkeypatch.setattr("app.ai_utils.requests.post", lambda *a, **k: MockResp())
-    resp = client.post("/gemini_articles/", json={"text": "hi"})
+    resp = client.post("/articles/", json={"text": "hi"})
     assert resp.status_code == 200
     assert resp.json() == [{"title": "A", "summary": "B"}]
 
 
-def test_gemini_articles_error(client, monkeypatch):
+def test_openrouter_articles_error(client, monkeypatch):
     def raise_exc(*args, **kwargs):
         raise requests.RequestException("bad")
 
-    monkeypatch.setenv("GEMINI_API_KEY", "dummy")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dummy")
     monkeypatch.setattr("app.ai_utils.requests.post", raise_exc)
-    resp = client.post("/gemini_articles/", json={"text": "hi"})
+    resp = client.post("/articles/", json={"text": "hi"})
     assert resp.status_code == 500
 
 
@@ -186,7 +182,7 @@ def test_openrouter_analyze(client, monkeypatch):
 
     monkeypatch.setenv("OPENROUTER_API_KEY", "dummy")
     monkeypatch.setattr("app.openrouter.requests.post", lambda *a, **k: MockResp())
-    resp = client.post("/openrouter_analyze/", json={"text": "hello"})
+    resp = client.post("/analyze/", json={"text": "hello"})
     assert resp.status_code == 200
     assert resp.json() == {"analysis": "Positif"}
 
@@ -197,5 +193,5 @@ def test_openrouter_analyze_error(client, monkeypatch):
 
     monkeypatch.setenv("OPENROUTER_API_KEY", "dummy")
     monkeypatch.setattr("app.openrouter.requests.post", raise_exc)
-    resp = client.post("/openrouter_analyze/", json={"text": "hello"})
+    resp = client.post("/analyze/", json={"text": "hello"})
     assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- drop unused Gemini API helpers and endpoints
- integrate OpenRouter for text analysis and article generation
- rename article request/response models
- update Android client and tests for new OpenRouter endpoints
- clean up README and build config references to Gemini

## Testing
- `pip install -r app/backend_api/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b809d3f48832489c91c1be72d2f42