### PR TITLE
Improve OpenRouter error handling

### DIFF
--- a/app/backend_api/app/main.py
+++ b/app/backend_api/app/main.py
@@ -6,6 +6,9 @@ from typing import List
 from .ai_utils import (
     caption_image_with_openrouter,
     generate_articles_with_openrouter,
+    MissingAPIKeyError,
+    NetworkError,
+    InvalidResponseError,
 )
 
 from . import crud
@@ -87,6 +90,10 @@ def generate_articles_endpoint(request: schemas.ArticleRequest):
 
     try:
         return generate_articles_with_openrouter(request.text)
+    except (NetworkError, InvalidResponseError) as e:
+        raise HTTPException(status_code=502, detail=str(e))
+    except MissingAPIKeyError as e:
+        raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to generate articles: {e}")
 


### PR DESCRIPTION
## Summary
- add custom exceptions for OpenRouter API errors and log invalid responses
- return 502 Bad Gateway when OpenRouter fails
- test missing key and bad JSON cases for article generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b90a215ac8324a22d07003d0d83c8