### PR TITLE
Add OpenRouter client helper and migrate API

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,14 @@ cd app/backend_api
 pip install -r requirements.txt
 ```
 
+File `requirements.txt` menyertakan paket `openai` yang digunakan helper
+`get_openrouter_client()` untuk terhubung ke layanan OpenRouter.
+
 ### Environment Variables
 
-Backend membutuhkan `OPENROUTER_API_KEY`. Simpan variabel ini di
-file `.env` lalu muat sebelum menjalankan server:
+Backend membutuhkan `OPENROUTER_API_KEY` untuk autentikasi ketika
+`get_openrouter_client()` memanggil API. Simpan variabel ini di file
+`.env` lalu muat sebelum menjalankan server:
 
 ```bash
 echo "OPENROUTER_API_KEY=your-openrouter-api-key" > .env

--- a/app/backend_api/app/openrouter.py
+++ b/app/backend_api/app/openrouter.py
@@ -1,13 +1,10 @@
-import os
-import requests
+from .openrouter_client import get_openrouter_client
 
 
 def analyze_text(text: str) -> str:
     """Analyze text sentiment using OpenRouter."""
 
-    api_key = os.getenv("OPENROUTER_API_KEY")
-    if not api_key:
-        raise RuntimeError("Missing OPENROUTER_API_KEY")
+    client = get_openrouter_client()
 
     payload = {
         "model": "google/gemini-2.0-flash-exp:free",
@@ -19,20 +16,8 @@ def analyze_text(text: str) -> str:
         ],
     }
 
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
-
     try:
-        response = requests.post(
-            "https://openrouter.ai/api/v1/chat/completions",
-            headers=headers,
-            json=payload,
-            timeout=10,
-        )
-        response.raise_for_status()
-        data = response.json()
-        return data["choices"][0]["message"]["content"]
+        data = client.chat.completions.create(**payload)
+        return data.choices[0].message.content
     except Exception as e:
         raise RuntimeError(f"Error from OpenRouter API: {e}")

--- a/app/backend_api/app/openrouter_client.py
+++ b/app/backend_api/app/openrouter_client.py
@@ -1,0 +1,9 @@
+from openai import OpenAI
+import os
+
+
+def get_openrouter_client() -> OpenAI:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        raise RuntimeError("Missing OPENROUTER_API_KEY")
+    return OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)

--- a/app/backend_api/requirements.txt
+++ b/app/backend_api/requirements.txt
@@ -6,3 +6,4 @@ passlib[bcrypt]==1.7.4
 httpx==0.27.0
 requests==2.31.0
 bcrypt<4.0.0
+openai==1.0.0


### PR DESCRIPTION
## Summary
- add `openai` dependency
- add helper `get_openrouter_client()`
- update OpenRouter utilities to use OpenAI client
- adjust tests for new interface
- mention OpenAI dependency in README

## Testing
- `pip install -r app/backend_api/requirements.txt`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684b98d378fc83249a72c0b222f64d09