### PR TITLE
Refine OpenRouter error handling

### DIFF
--- a/app/backend_api/app/openrouter.py
+++ b/app/backend_api/app/openrouter.py
@@ -1,5 +1,6 @@
 from .openrouter_client import get_openrouter_client
-import json
+import logging
+
 
 def analyze_text(text: str) -> str:
     """Analyze text sentiment using OpenRouter."""
@@ -30,7 +31,5 @@ def analyze_text(text: str) -> str:
 
     except Exception as e:
         # Menangkap error lain dari OpenRouter API atau Python
-        print(f"ERROR: Kesalahan API OpenRouter atau pemrosesan: {e}")
-        # Kembalikan pesan error umum, agar klien tidak mendapatkan detail internal
-        return "Gagal menganalisis sentimen: Terjadi kesalahan tidak terduga."
-
+        logging.error("ERROR: Kesalahan API OpenRouter atau pemrosesan: %s", e)
+        raise RuntimeError("Gagal menganalisis sentimen") from e

--- a/app/backend_api/app/openrouter_client.py
+++ b/app/backend_api/app/openrouter_client.py
@@ -1,9 +1,13 @@
 import os
+import logging
 from dotenv import load_dotenv
 from openai import OpenAI
 
 # Memuat variabel dari file .env ke dalam environment
 load_dotenv()
+
+logger = logging.getLogger(__name__)
+
 
 def get_openrouter_client() -> OpenAI:
     """
@@ -12,19 +16,15 @@ def get_openrouter_client() -> OpenAI:
     """
     api_key = os.getenv("OPENROUTER_API_KEY")
 
-    # --- BLOK DEBUGGING ---
-    # Kode berikut akan mencetak nilai API Key yang terbaca ke terminal Anda.
-    # Ini membantu memastikan bahwa file .env Anda dimuat dengan benar.
-    print("--- Memeriksa Kunci API OpenRouter ---")
     if api_key:
-        print(f"DEBUG: Kunci API ditemukan. Panjang: {len(api_key)} karakter.")
-        # Untuk keamanan, kita hanya akan menampilkan beberapa karakter pertama dan terakhir
-        print(f"DEBUG: Kunci dimulai dengan '{api_key[:4]}' dan diakhiri dengan '{api_key[-4:]}'.")
+        logger.debug(
+            "OpenRouter API key loaded (length: %d, prefix: %s, suffix: %s)",
+            len(api_key),
+            api_key[:4],
+            api_key[-4:],
+        )
     else:
-        # Pesan ini akan muncul jika os.getenv() tidak menemukan variabelnya.
-        print("DEBUG: KESALAHAN! Variabel OPENROUTER_API_KEY tidak ditemukan di environment.")
-    print("------------------------------------")
-    # --- AKHIR BLOK DEBUGGING ---
+        logger.debug("OPENROUTER_API_KEY not found in environment")
 
     # Logika ini tetap sama. Jika kunci tidak ada, program akan berhenti.
     # Ini adalah pengaman jika terjadi kesalahan.
@@ -35,7 +35,4 @@ def get_openrouter_client() -> OpenAI:
         )
 
     # Mengembalikan klien yang sudah diinisialisasi
-    return OpenAI(
-        base_url="https://openrouter.ai/api/v1",
-        api_key=api_key
-    )
+    return OpenAI(base_url="https://openrouter.ai/api/v1", api_key=api_key)


### PR DESCRIPTION
## Summary
- clean up OpenRouter client debug output and use logging
- report OpenRouter errors via logging and exceptions

## Testing
- `pip install -r requirements.txt`
- `pip install python-dotenv`
- `pytest -q` *(fails: OpenRouter articles test expects 200 but got 502)*

------
https://chatgpt.com/codex/tasks/task_e_684c43eb5fbc83248eb874cd6f2d0c8e