### PR TITLE
Remove unused environment helper

### DIFF
--- a/app/backend_api/test_env.py
+++ b/app/backend_api/test_env.py
@@ -1,5 +1,0 @@
-from dotenv import load_dotenv
-import os
-
-load_dotenv()
-print("API KEY:", os.getenv("OPENROUTER_API_KEY"))


### PR DESCRIPTION
## Summary
- drop obsolete `test_env.py`

## Testing
- `pytest -q` *(fails: test_openrouter_articles)*

------
https://chatgpt.com/codex/tasks/task_e_684c467f169083248a4067a1aae29c32