### PR TITLE
Handle plain JSON fallback

### DIFF
--- a/app/backend_api/app/ai_utils.py
+++ b/app/backend_api/app/ai_utils.py
@@ -47,10 +47,9 @@ def extract_json_from_markdown(text: str) -> str:
     if match:
         return match.group(1).strip()
 
-    # If the response is plain JSON, return it as-is so the caller can attempt
-    # to parse it.
+    # Fall back to returning the raw text when no fenced block is found.
     stripped = text.strip()
-    if stripped.startswith("[") or stripped.startswith("{"):
+    if stripped:
         return stripped
 
     raise InvalidResponseError("Tidak ditemukan blok JSON dalam respons OpenRouter.")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 import pytest
-import requests
 import httpx
 
 os.environ["SQLALCHEMY_DATABASE_URL"] = "sqlite:///:memory:"


### PR DESCRIPTION
## Summary
- adjust `extract_json_from_markdown` to simply return raw text when no fenced block is found
- remove unused `requests` import from tests
- keep tests expecting 500 when analysis fails

## Testing
- `pip install -q -r app/backend_api/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4a1429788324816e0aa793d5dd61