### PR TITLE
Update splash screen timing and visuals

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/SplashActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/SplashActivity.kt
@@ -11,6 +11,8 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,6 +20,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.MaterialTheme
 import com.example.diarydepresiku.ui.theme.DiarydepresikuTheme
+import com.example.diarydepresiku.ui.theme.Blue80
 import kotlinx.coroutines.delay
 
 class SplashActivity : ComponentActivity() {
@@ -49,19 +52,23 @@ private fun SplashScreen(onTimeout: () -> Unit) {
     // Trigger animasi dan timeout
     LaunchedEffect(Unit) {
         visible = true
-        delay(1500)
+        delay(3000)
         onTimeout()
     }
 
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(
+                Brush.linearGradient(
+                    colors = listOf(Blue80, Color.White)
+                )
+            ),
         contentAlignment = Alignment.Center
     ) {
         AnimatedVisibility(
             visible = visible,
-            enter = fadeIn(animationSpec = tween(1000))
+            enter = fadeIn(animationSpec = tween(3000))
         ) {
             Image(
                 painter = painterResource(id = R.drawable.app_logo),


### PR DESCRIPTION
## Summary
- extend splash screen delay and animation times
- add gradient background to splash screen
- import `Blue80` from theme

## Testing
- `./gradlew lint` *(fails: SDK location not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c51ea54bc83248c3c034ea7437c8c