### PR TITLE
Use resources for UI strings

### DIFF
--- a/app/src/main/java/com/example/diarydepresiku/LoginActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/LoginActivity.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
@@ -92,14 +93,14 @@ fun LoginScreen(
         OutlinedTextField(
             value = email,
             onValueChange = { email = it },
-            label = { Text("Email") },
+            label = { Text(stringResource(R.string.label_email)) },
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(Modifier.height(12.dp))
         OutlinedTextField(
             value = password,
             onValueChange = { password = it },
-            label = { Text("Password") },
+            label = { Text(stringResource(R.string.label_password)) },
             visualTransformation = PasswordVisualTransformation(),
             modifier = Modifier.fillMaxWidth()
         )
@@ -108,21 +109,21 @@ fun LoginScreen(
             onClick = { onLogin(email, password) },
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text("Login")
+            Text(stringResource(R.string.action_login))
         }
         Spacer(Modifier.height(8.dp))
         Button(
             onClick = onGoogle,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text("Sign in with Google")
+            Text(stringResource(R.string.action_sign_in_google))
         }
         Spacer(Modifier.height(8.dp))
         TextButton(
             onClick = onRegister,
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text("Register")
+            Text(stringResource(R.string.action_register))
         }
 
         Row(
@@ -138,7 +139,7 @@ fun LoginScreen(
             )
             Spacer(Modifier.width(8.dp))
             Text(
-                text = "Privasi Anda terlindungi dengan enkripsi end-to-end.",
+                text = stringResource(R.string.privacy_message),
                 color = SoftYellow,
                 style = MaterialTheme.typography.labelSmall
             )

--- a/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.*
 
@@ -91,8 +92,8 @@ class MainActivity : ComponentActivity() {
                                         launchSingleTop = true
                                     }
                                 },
-                                icon = { Icon(Icons.Filled.Home, contentDescription = "Home") },
-                                label = { Text("Home") },
+                                icon = { Icon(Icons.Filled.Home, contentDescription = stringResource(R.string.nav_home)) },
+                                label = { Text(stringResource(R.string.nav_home)) },
                                 alwaysShowLabel = true
                             )
                             NavigationBarItem(
@@ -103,8 +104,8 @@ class MainActivity : ComponentActivity() {
                                         launchSingleTop = true
                                     }
                                 },
-                                icon = { Icon(Icons.Filled.History, contentDescription = "History") },
-                                label = { Text("History") },
+                                icon = { Icon(Icons.Filled.History, contentDescription = stringResource(R.string.nav_history)) },
+                                label = { Text(stringResource(R.string.nav_history)) },
                                 alwaysShowLabel = true
                             )
                             NavigationBarItem(
@@ -115,8 +116,8 @@ class MainActivity : ComponentActivity() {
                                         launchSingleTop = true
                                     }
                                 },
-                                icon = { Icon(Icons.Filled.Person, contentDescription = "Profile") },
-                                label = { Text("Profile") },
+                                icon = { Icon(Icons.Filled.Person, contentDescription = stringResource(R.string.nav_profile)) },
+                                label = { Text(stringResource(R.string.nav_profile)) },
                                 alwaysShowLabel = true
                             )
 

--- a/app/src/main/java/com/example/diarydepresiku/RegisterActivity.kt
+++ b/app/src/main/java/com/example/diarydepresiku/RegisterActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
@@ -55,21 +56,21 @@ fun RegisterScreen(onRegister: (String, String, String) -> Unit) {
         OutlinedTextField(
             value = name,
             onValueChange = { name = it },
-            label = { Text("Name") },
+            label = { Text(stringResource(R.string.label_name)) },
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(Modifier.height(8.dp))
         OutlinedTextField(
             value = email,
             onValueChange = { email = it },
-            label = { Text("Email") },
+            label = { Text(stringResource(R.string.label_email)) },
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(Modifier.height(8.dp))
         OutlinedTextField(
             value = password,
             onValueChange = { password = it },
-            label = { Text("Password") },
+            label = { Text(stringResource(R.string.label_password)) },
             visualTransformation = PasswordVisualTransformation(),
             modifier = Modifier.fillMaxWidth()
         )
@@ -78,7 +79,7 @@ fun RegisterScreen(onRegister: (String, String, String) -> Unit) {
             onClick = { onRegister(email, password, name) },
             modifier = Modifier.fillMaxWidth()
         ) {
-            Text("Register")
+            Text(stringResource(R.string.action_register))
         }
 
         Row(
@@ -94,7 +95,7 @@ fun RegisterScreen(onRegister: (String, String, String) -> Unit) {
             )
             Spacer(Modifier.width(4.dp))
             Text(
-                text = "Privasi Anda terlindungi dengan enkripsi end-to-end.",
+                text = stringResource(R.string.privacy_message),
                 color = SoftYellow,
                 style = MaterialTheme.typography.labelSmall
             )

--- a/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/DiaryFormScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api // <<< PENTING: Untuk
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -166,7 +167,7 @@ fun DiaryFormScreen(
             )
             Spacer(Modifier.width(4.dp))
             Text(
-                text = "Privasi Anda terlindungi dengan enkripsi end-to-end.",
+                text = stringResource(R.string.privacy_message),
                 color = SoftYellow,
                 style = MaterialTheme.typography.labelSmall
             )

--- a/app/src/main/java/com/example/diarydepresiku/ui/ReminderSettingsScreen.kt
+++ b/app/src/main/java/com/example/diarydepresiku/ui/ReminderSettingsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.example.diarydepresiku.ui.theme.SoftYellow
 import androidx.compose.material.icons.Icons
@@ -107,7 +108,7 @@ fun ReminderSettingsScreen(
             )
             Spacer(Modifier.width(4.dp))
             Text(
-                text = "Privasi Anda terlindungi dengan enkripsi end-to-end.",
+                text = stringResource(R.string.privacy_message),
                 color = SoftYellow,
                 style = MaterialTheme.typography.labelSmall
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,13 @@
 <resources>
     <string name="app_name">diarydepresiku</string>
+    <string name="label_email">Email</string>
+    <string name="label_password">Password</string>
+    <string name="label_name">Name</string>
+    <string name="action_login">Login</string>
+    <string name="action_register">Register</string>
+    <string name="action_sign_in_google">Sign in with Google</string>
+    <string name="privacy_message">Privasi Anda terlindungi dengan enkripsi end-to-end.</string>
+    <string name="nav_home">Home</string>
+    <string name="nav_history">History</string>
+    <string name="nav_profile">Profile</string>
 </resources>


### PR DESCRIPTION
## Summary
- add common label strings
- replace hardcoded text in Compose files with `stringResource`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c53f64408832496e403375ff12951