### PR TITLE
Remove hardcoded API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ NEWS_API_KEY=your-news-api-key
 OPENROUTER_API_KEY=your-openrouter-api-key
 ```
 
+Gradle akan membaca nilai tersebut melalui fungsi `secret("OPENROUTER_API_KEY")`
+di `app/build.gradle.kts` dan meneruskannya ke `buildConfigField`.
+
 File `local.properties` sudah ada di `.gitignore`, sehingga kunci rahasia tidak
 terikut saat commit.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,7 +33,8 @@ android {
         // Base URL for backend API
         buildConfigField("String", "BASE_URL", "\"http://10.0.2.2:8000/\"")
         // API keys loaded from local.properties or Gradle properties
-        buildConfigField("String", "OPENROUTER_API_KEY", "\"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\"")
+        val openRouter = secret("OPENROUTER_API_KEY") ?: ""
+        buildConfigField("String", "OPENROUTER_API_KEY", "\"$openRouter\"")
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true


### PR DESCRIPTION
## Summary
- load `OPENROUTER_API_KEY` from `local.properties`
- document how Gradle reads API keys

## Testing
- `pip install -r app/backend_api/requirements.txt`
- `pytest -q`
- `./gradlew lintFix` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685528dd85f48324a1481d738e509c00