### PR TITLE
Add chat endpoint using OpenRouter

### DIFF
--- a/app/backend_api/app/schemas.py
+++ b/app/backend_api/app/schemas.py
@@ -81,6 +81,14 @@ class ArticleResponse(BaseModel):
     summary: str
 
 
+class ChatRequest(BaseModel):
+    """Request body for the /chat/ endpoint."""
+
+    text: str = Field(..., min_length=1)
+    history: str | None = None
+    mood: str | None = None
+
+
 class OpenRouterCaptionRequest(BaseModel):
     """Request body for describing an image via OpenRouter."""
 


### PR DESCRIPTION
## Summary
- create `chat_with_openrouter` helper for two-step OpenRouter flow
- add new `ChatRequest` schema
- expose `/chat/` API endpoint returning plain text
- test chat success, bad JSON and missing API key

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552abdf9f08324888e070e69c6880f