### PR TITLE
Handle OpenRouter network failures

### DIFF
--- a/app/backend_api/app/main.py
+++ b/app/backend_api/app/main.py
@@ -105,6 +105,8 @@ def chat(request: schemas.ChatRequest):
         return Response(content=result, media_type="text/plain")
     except MissingAPIKeyError as e:
         raise HTTPException(status_code=500, detail=f"API Key tidak ditemukan: {str(e)}")
+    except NetworkError as e:
+        raise HTTPException(status_code=502, detail=f"OpenRouter error: {str(e)}")
     except InvalidResponseError as e:
         raise HTTPException(status_code=502, detail=f"OpenRouter error: {str(e)}")
 
@@ -134,6 +136,10 @@ async def caption_image(request: schemas.OpenRouterCaptionRequest):
     try:
         caption = await caption_image_with_openrouter(request.image_url)
         return {"caption": caption}
+    except MissingAPIKeyError as e:
+        raise HTTPException(status_code=500, detail=f"API Key tidak ditemukan: {str(e)}")
+    except NetworkError as e:
+        raise HTTPException(status_code=502, detail=f"OpenRouter error: {str(e)}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Gagal membuat caption: {e}")
 


### PR DESCRIPTION
## Summary
- handle httpx/OpenAI errors in ai_utils and raise NetworkError
- return 502 for NetworkError in chat and caption routes
- test network error handling

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68552bd1a0e48324a208f5caa3194d3f